### PR TITLE
Fix template crash on pull requests in the repo dashboard

### DIFF
--- a/pkg/template/pages/repo_dashboard.html
+++ b/pkg/template/pages/repo_dashboard.html
@@ -33,7 +33,7 @@
 							<a href="/{{$repo.Slug}}/commit/{{.Hash}}">{{.HashShort}}</a>
 							<small class="timeago" title="{{.CreatedString}}"></small>
 							{{ if .PullRequest }}
-								<p>opened pull request <a href="/{{.Slug}}/commit/{{.Hash}}"># {{.PullRequest}}</a></p>
+								<p>opened pull request <a href="/{{$repo.Slug}}/commit/{{.Hash}}"># {{.PullRequest}}</a></p>
 							{{ else }}
 								<p>{{.Message}} &nbsp;</p>
 							{{ end }}


### PR DESCRIPTION
Builds triggered via a pull request were showing an error in the label field: 
`/template: _:36:43: executing " content"="" at="" <.slug="">: Slug is not a field of struct type *model.Commit`
