### PR TITLE
Add post installation and pre removal script for debian package.

### DIFF
--- a/deb/drone/DEBIAN/postinst
+++ b/deb/drone/DEBIAN/postinst
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+  abort-upgrade|abort-remove|abort-deconfigure|configure)
+    ;;
+
+  *)
+    echo "postinst called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+echo "Starting drone ..."
+if [ -f /etc/init/drone.conf ]; then
+    if pidof /usr/local/bin/droned >/dev/null; then
+        service drone stop || exit $?
+    fi
+    service drone start && echo "Drone started."
+fi
+
+#DEBHELPER#
+
+exit 0

--- a/deb/drone/DEBIAN/prerm
+++ b/deb/drone/DEBIAN/prerm
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+set -u
+
+case "$1" in
+  remove|remove-in-favour|deconfigure|deconfigure-in-favour)
+    if [ -f /etc/init/drone.conf ]; then
+      echo "Stopping drone ..."
+      service drone stop || exit $?
+      echo "Drone Stopped."
+    fi
+    ;;
+
+  upgrade|failed-upgrade)
+    ;;
+
+  *)
+    echo "prerm called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0


### PR DESCRIPTION
Current debian package wont stop droned when uninstalled.
Add maintainer script to do this.
Also auto-start droned when installed from deb, safe assuming that other real web server may already occupy port 80, set 8080 as default port to listen to.
