### PR TITLE
Fixes for Github status reporting

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/drone/drone/pkg/mail"
 	. "github.com/drone/drone/pkg/model"
 	"github.com/drone/go-github/github"
+	"log"
 	"path/filepath"
 	"time"
 )
@@ -134,6 +135,15 @@ func (b *BuildTask) execute() error {
 	builder.Key = []byte(b.Repo.PrivateKey)
 	builder.Stdout = buf
 	builder.Timeout = 300 * time.Minute
+
+	defer func() {
+		// update the status of the commit using the
+		// GitHub status API.
+		if err := updateGitHubStatus(b.Repo, b.Commit); err != nil {
+			log.Printf("error updating github status: %s\n", err.Error())
+		}
+	}()
+
 	buildErr := builder.Run()
 
 	b.Build.Finished = time.Now().UTC()
@@ -179,12 +189,6 @@ func (b *BuildTask) execute() error {
 	if b.Script.Notifications != nil {
 		b.sendEmail(context) // send email from queue, not from inside /build/script package
 		b.Script.Notifications.Send(context)
-	}
-
-	// update the status of the commit using the
-	// GitHub status API.
-	if err := updateGitHubStatus(b.Repo, b.Commit); err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
Firstly there was a tiny syntax error causing `updateGitHubStatus()` to always return prematurely which prevented statuses from ever being reported.

The second commit defers updating the status rather than explicitly calling it at the end of `execute()`. This is a personal preference so let me know if you'd like to change it. Due to some weirdness in my dev environment I was seeing builds fail much earlier so it seems to make sense that an error in Drone is a valid reason to report a build error on the pull request (or at least call out that it couldn't be built).
