### PR TITLE
Show an inline error if the wrong password is given when deleting a repo

### DIFF
--- a/pkg/handler/repos.go
+++ b/pkg/handler/repos.go
@@ -274,7 +274,7 @@ func RepoDelete(w http.ResponseWriter, r *http.Request, u *User, repo *Repo) err
 	// the user must confirm their password before deleting
 	password := r.FormValue("password")
 	if err := u.ComparePassword(password); err != nil {
-		return err
+		return RenderError(w, err, http.StatusBadRequest)
 	}
 
 	// delete the repo

--- a/pkg/template/pages/repo_delete.html
+++ b/pkg/template/pages/repo_delete.html
@@ -40,6 +40,7 @@
 					<div>
 						<input class="form-control" type="password" name="password" value="" />
 					</div>
+					<div class="alert alert-error hide" id="failureAlert"></div>
 					<div class="form-actions">
 						<input class="btn btn-danger" id="submitButton" type="submit" value="Delete Repository" />
 						<a class="btn btn-default" href="/{{.Repo.Slug}}/settings">Cancel</a>
@@ -51,4 +52,27 @@
 {{ end }}
 
 {{ define "script" }}
+	<script>
+		document.forms[0].onsubmit = function(event) {
+
+						$("#failureAlert").hide();
+						$('#submitButton').button('loading');
+
+						var form = event.target
+						var formData = new FormData(form);
+						xhr = new XMLHttpRequest();
+						xhr.open('POST', form.action);
+						xhr.onload = function() {
+								if (this.status == 400) {
+										$("#failureAlert").text("The password you entered was incorrect.");
+										$("#failureAlert").show().removeClass("hide");
+										$('#submitButton').button('reset')
+								} else {
+										window.location.href = "/dashboard";
+								}
+						};
+						xhr.send(formData);
+						return false;
+				}
+	</script>
 {{ end }}


### PR DESCRIPTION
Previously if you entered the wrong password when deleting a repo you'd navigate away from the page and get the `go.crypto/bcrypt` error saying that the passwords don't match. Since this is an expected case I've added an inline error, similar to what you'd see when adding a user or repo, to show what went wrong. This could be expanded on later for 500-level errors.
