### PR TITLE
Fix HTML closing errors

### DIFF
--- a/pkg/template/pages/github_add.html
+++ b/pkg/template/pages/github_add.html
@@ -16,9 +16,10 @@
 				<ul class="nav nav-pills nav-stacked">
 					<li class="active"><a href="/new/github.com">GitHub</a></li>
 					<li><a href="/new/bitbucket.org">Bitbucket <small>(coming soon)</small></a></li>
-				</div><!-- ./col-xs-3 -->
+				</ul>
+			</div><!-- ./col-xs-3 -->
 
-				<div class="col-xs-9" role="main">
+			<div class="col-xs-9" role="main">
 					<div class="alert">
 						Enter your repository details
 						<a class="btn btn-default pull-right" href="/auth/login/github" style="font-size: 18px;background:#f4f4f4;">Re-Link Account</a>

--- a/pkg/template/pages/github_link.html
+++ b/pkg/template/pages/github_link.html
@@ -16,9 +16,10 @@
 				<ul class="nav nav-pills nav-stacked">
 					<li class="active"><a href="/new/github.com">GitHub</a></li>
 					<li><a href="/new/bitbucket.org">Bitbucket <small>(coming soon)</small></a></li>
-				</div><!-- ./col-xs-3 -->
+				</ul>
+			</div><!-- ./col-xs-3 -->
 
-				<div class="col-xs-9" role="main">
+			<div class="col-xs-9" role="main">
 					<div class="alert">Link Your GitHub Account
 						<a class="btn btn-primary pull-right" href="/auth/login/github" style="font-size: 18px;">Link Now</a>
 					</div>


### PR DESCRIPTION
github_add.html and github_link.html don't close the `<ul>` properly have a incorrect indenting. This pull request at least fixes the `<ul>` closing problem. All the code inside `role="main"` needs to be unindented by 1 level, but I've chosen not to include that in this patch, in order to make review easier.
