### PR TITLE
Add web UI for adding self-hosted git repositories

### DIFF
--- a/cmd/droned/drone.go
+++ b/cmd/droned/drone.go
@@ -92,7 +92,9 @@ func setupHandlers() {
 
 	// handlers for setting up your GitHub repository
 	m.Post("/new/github.com", handler.UserHandler(handler.RepoCreateGithub))
-	m.Get("/new/github.com", handler.UserHandler(handler.RepoAdd))
+	m.Get("/new/github.com", handler.UserHandler(handler.RepoAddGithub))
+	m.Post("/new/custom_git", handler.UserHandler(handler.RepoCreateCustomGit))
+	m.Get("/new/custom_git", handler.UserHandler(handler.RepoAddCustomGit))
 
 	// handlers for linking your GitHub account
 	m.Get("/auth/login/github", handler.UserHandler(handler.LinkGithub))

--- a/pkg/model/repo.go
+++ b/pkg/model/repo.go
@@ -25,6 +25,10 @@ const (
 )
 
 const (
+	UserCustomGit    = "Custom"
+)
+
+const (
 	githubRepoPattern           = "git://github.com/%s/%s.git"
 	githubRepoPatternPrivate    = "git@github.com:%s/%s.git"
 	bitbucketRepoPattern        = "https://bitbucket.org/%s/%s.git"

--- a/pkg/template/pages/custom_git_add.html
+++ b/pkg/template/pages/custom_git_add.html
@@ -1,0 +1,95 @@
+{{ define "title" }}Custom Git repo · Add Repository{{ end }}
+
+{{ define "content" }}
+	<div class="subhead">
+		<div class="container">
+			<h1>
+				<span>Repository Setup</span>
+				<small>Custom Git repo</small>
+			</h1>
+		</div><!-- ./container -->
+ 	</div><!-- ./subhead -->
+
+	<div class="container">
+		<div class="row">
+			<div class="col-xs-3">
+				<ul class="nav nav-pills nav-stacked">
+					<li><a href="/new/github.com">GitHub</a></li>
+					<li><a href="/new/bitbucket.org">Bitbucket <small>(coming soon)</small></a></li>
+					<li class="active"><a href="/new/custom_git">Custom Git repo</a></li>
+				</ul>
+			</div><!-- ./col-xs-3 -->
+
+			<div class="col-xs-9" role="main">
+				<form class="form-repo" method="POST" action="/new/custom_git">
+					<div class="field-group">
+						<div>
+							<label>Repository Name</label>
+						<div>
+							<input class="form-control form-control-large" type="text" name="name" autocomplete="off">
+						</div>
+					</div>
+					<br/>
+					<div class="field-group">
+						<div>
+							<label>URL</label>
+							<div>
+								<input class="form-control form-control-large" type="text" name="url">
+							</div>
+						</div>
+					</div>
+					<br/>
+					<div class="alert">Select your Drone account</div>
+					<ul>
+						<li>
+							<input type="radio" name="team" checked="True" value="">
+							<img src="{{ .User.Image }}?s=32">
+							<span>Me</span>
+						</li>
+						{{ range .Teams }}
+						<li>
+							<input type="radio" name="team" value="{{ .Slug }}">
+							<img src="{{ .Image }}?s=32">
+							<span>{{ .Name }}</span>
+						</li>
+						{{ end }}
+					</ul>
+					<div class="alert alert-success hide" id="successAlert"></div>
+					<div class="alert alert-error hide" id="failureAlert"></div>
+					<div class="form-actions">
+						<input class="btn btn-primary" id="submitButton" type="submit" value="Add" data-loading-text="Saving ..">
+						<a class="btn btn-default" href="/dashboard">Cancel</a>
+					</div>
+				</form>
+			</div><!-- ./col-xs-9 -->
+		</div><!-- ./row -->
+	</div><!-- ./container -->
+{{ end }}
+
+{{ define "script" }}
+	<script>
+		document.forms[0].onsubmit = function(event) {
+			$("#successAlert").hide();
+			$("#failureAlert").hide();
+			$('#submitButton').button('loading')
+			
+			var form = event.target
+			var formData = new FormData(form);
+			xhr = new XMLHttpRequest();
+			xhr.open('POST', form.action);
+			xhr.onload = function() {
+				if (this.status == 200) {
+					var name = $("input[name=name]").val()
+					var owner = $("input[name=owner]").val()
+					window.location.pathname = "/custom/Custom/"+name
+				} else {
+					$("#failureAlert").text("Unable to setup the Repository");
+					$("#failureAlert").show().removeClass("hide");
+					$('#submitButton').button('reset')
+				};
+			};
+			xhr.send(formData);
+			return false;
+		}
+	</script>
+{{ end }}

--- a/pkg/template/pages/github_add.html
+++ b/pkg/template/pages/github_add.html
@@ -16,6 +16,7 @@
 				<ul class="nav nav-pills nav-stacked">
 					<li class="active"><a href="/new/github.com">GitHub</a></li>
 					<li><a href="/new/bitbucket.org">Bitbucket <small>(coming soon)</small></a></li>
+					<li><a href="/new/custom_git">Custom Git repo</a></li>
 				</ul>
 			</div><!-- ./col-xs-3 -->
 

--- a/pkg/template/pages/github_link.html
+++ b/pkg/template/pages/github_link.html
@@ -16,6 +16,7 @@
 				<ul class="nav nav-pills nav-stacked">
 					<li class="active"><a href="/new/github.com">GitHub</a></li>
 					<li><a href="/new/bitbucket.org">Bitbucket <small>(coming soon)</small></a></li>
+					<li><a href="/new/custom_git">Custom Git repo</a></li>
 				</ul>
 			</div><!-- ./col-xs-3 -->
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -78,6 +78,7 @@ func init() {
 		"admin_settings.html",
 		"github_add.html",
 		"github_link.html",
+		"custom_git_add.html",
 	}
 
 	// extract the base template as a string


### PR DESCRIPTION
This pull request adds a web UI for adding self-hosted git repositories (see issue #10). This pull request is only a partial solution. Things that I haven't implemented yet:
- A web UI that instructs the user to add the Drone public key.
- A webhook self-hosted git repos.

This pull request depends on pull request #33.
