### PR TITLE
Read the actual commit status when updating Github

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -201,7 +201,7 @@ func updateGitHubStatus(repo *Repo, commit *Commit) error {
 
 	// convert from drone status to github status
 	var message, status string
-	switch status {
+	switch commit.Status {
 	case "Success":
 		status = "success"
 		message = "The build succeeded on drone.io"


### PR DESCRIPTION
Another minor fix for the Github status issues. Previously it reported the status but they always qualified as errors. I've got this tested and working well in my internal environment now.
