### PR TITLE
Add: get git submodules in one step

### DIFF
--- a/pkg/build/repo/repo.go
+++ b/pkg/build/repo/repo.go
@@ -94,7 +94,7 @@ func (r *Repo) Commands() []string {
 	branch := r.Branch
 	if len(branch) == 0 {
 		branch = "master"
-	}r
+	}
 
 	cmds := []string{}
 	cmds = append(cmds, fmt.Sprintf("git clone --recursive --branch=%s %s %s", branch, r.Path, r.Dir))


### PR DESCRIPTION
--recursive
--recurse-submodules
After the clone is created, initialize all submodules within, using their default settings. This is equivalent to running git submodule update --init --recursive immediately after the clone is finished. This option is ignored if the cloned repository does not have a worktree/checkout (i.e. if any of --no-checkout/-n, --bare, or --mirror is given)

from http://git-scm.com/docs/git-clone
