### PR TITLE
Fixed the overflow of the url when adding an admin user or a team member.

### DIFF
--- a/cmd/droned/assets/css/drone.css
+++ b/cmd/droned/assets/css/drone.css
@@ -1074,3 +1074,6 @@ ul.account-radio-group li img {
   padding: 20px;
   margin-bottom: 30px;
 }
+.url {
+  word-break: break-all;
+}

--- a/cmd/droned/assets/css/drone.less
+++ b/cmd/droned/assets/css/drone.less
@@ -1261,3 +1261,7 @@ pre {
             margin-bottom:30px;
         }
 }
+
+.url {
+  word-break: break-all;
+}

--- a/pkg/template/pages/admin_users_add.html
+++ b/pkg/template/pages/admin_users_add.html
@@ -59,9 +59,9 @@
 								if (this.status == 200) {
 										var msg = "User Invitation was sent successfully";
 										if (this.responseText != "OK") {
-												msg = "Email is not currently enabled.  In order to invite the user, you'll need to provide them the following link: " + this.responseText;
+												msg = "Email is not currently enabled.  In order to invite the user, you'll need to provide them the following link:<br><span class='url'>" + this.responseText + "</span>";
 										}
-										$("#successAlert").text(msg);
+										$("#successAlert").html(msg);
 										$("#successAlert").show().removeClass("hide");
 										$('#submitButton').button('reset')
 										

--- a/pkg/template/pages/members_add.html
+++ b/pkg/template/pages/members_add.html
@@ -69,9 +69,9 @@
 								if (this.status == 200) {
 										var msg = "An invitation has been sent (via email) to join the Team.";
 										if (this.responseText != "OK") {
-												msg = "Email is not currently enabled.  In order to invite this team member user, you'll need to provide them the following link: " + this.responseText;
+												msg = "Email is not currently enabled.  In order to invite this team member user, you'll need to provide them the following link:<br><span class='url'>" + this.responseText + "</span>";
 										}
-										$("#successAlert").text(msg);
+										$("#successAlert").html(msg);
 										$("#successAlert").show().removeClass("hide");
 										$('#submitButton').button('reset')
 								} else {


### PR DESCRIPTION
Fixed the overflow of the alert message's url when adding an admin user or a team member. (See the screen shot attached.)

![screen shot 2014-02-12 at 9 44 05](https://f.cloud.github.com/assets/1583973/2144470/121fdeb2-9388-11e3-9846-68e635376e8e.png)
