### PR TITLE
Added the `on_started`, `on_success`, `on_failure` properties on the notify.hipchat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ publish:
 
 ### Notifications
 
-Drone can trigger email, hipchat and web hook notification at the completion
-of your build:
+Drone can trigger email, hipchat and web hook notification at the beginning and
+completion of your build:
 
 ```
 notify:
@@ -204,7 +204,10 @@ notify:
 
   hipchat:
     room: support
-	token: 3028700e5466d375
+    token: 3028700e5466d375
+    on_started: true
+    on_success: true
+    on_failure: true
 ```
 
 ### Docs


### PR DESCRIPTION
Added the `on_started`, `on_success`, `on_failure` properties on the notify.hipchat so that README readers can know that these properties are available.
