### PR TITLE
Implemented a function for developers to specify the `--depth` option of the `git clone` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ notify:
 	token: 3028700e5466d375
 ```
 
+### Git Command Options
+
+You can specify the `--depth` option of the `git clone` command (Defalut value is `50`):
+
+```
+git:
+  depth: 1
+```
+
 ### Docs
 
 Coming Soon to [drone.readthedocs.org](http://drone.readthedocs.org/)

--- a/pkg/build/git/git.go
+++ b/pkg/build/git/git.go
@@ -1,0 +1,22 @@
+package git
+
+const (
+	DefaultGitDepth = 50
+)
+
+// Git stores the configuration details for
+// executing Git commands.
+type Git struct {
+	Depth *int `yaml:"depth,omitempty"`
+}
+
+// GitDepth returns GitDefaultDepth
+// when Git.Depth is empty.
+// GitDepth returns Git.Depth
+// when it is not empty.
+func GitDepth(g *Git) int {
+	if g == nil || g.Depth == nil {
+		return DefaultGitDepth
+	}
+	return *g.Depth
+}

--- a/pkg/build/git/git_test.go
+++ b/pkg/build/git/git_test.go
@@ -1,0 +1,40 @@
+package git
+
+import (
+	"testing"
+)
+
+func TestGitDepth(t *testing.T) {
+	var g *Git
+	var expected int
+
+	expected = DefaultGitDepth
+	g = nil
+	if actual := GitDepth(g); actual != expected {
+		t.Errorf("The result is invalid. [expected: %d][actual: %d]", expected, actual)
+	}
+
+	expected = DefaultGitDepth
+	g = &Git{}
+	if actual := GitDepth(g); actual != expected {
+		t.Errorf("The result is invalid. [expected: %d][actual: %d]", expected, actual)
+	}
+
+	expected = DefaultGitDepth
+	g = &Git{Depth: nil}
+	if actual := GitDepth(g); actual != expected {
+		t.Errorf("The result is invalid. [expected: %d][actual: %d]", expected, actual)
+	}
+
+	expected = 0
+	g = &Git{Depth: &expected}
+	if actual := GitDepth(g); actual != expected {
+		t.Errorf("The result is invalid. [expected: %d][actual: %d]", expected, actual)
+	}
+
+	expected = 1
+	g = &Git{Depth: &expected}
+	if actual := GitDepth(g); actual != expected {
+		t.Errorf("The result is invalid. [expected: %d][actual: %d]", expected, actual)
+	}
+}

--- a/pkg/build/repo/repo.go
+++ b/pkg/build/repo/repo.go
@@ -33,6 +33,9 @@ type Repo struct {
 	// will be cloned into (or copied to) inside the
 	// host system (Docker Container).
 	Dir string
+
+	// (optional) The depth of the `git clone` command.
+	Depth int
 }
 
 // IsRemote returns true if the Repository is located
@@ -88,7 +91,6 @@ func (r *Repo) IsGit() bool {
 //
 // TODO we should also enable Mercurial projects and SVN projects
 func (r *Repo) Commands() []string {
-
 	// get the branch. default to master
 	// if no branch exists.
 	branch := r.Branch
@@ -97,7 +99,7 @@ func (r *Repo) Commands() []string {
 	}
 
 	cmds := []string{}
-	cmds = append(cmds, fmt.Sprintf("git clone --recursive --branch=%s %s %s", branch, r.Path, r.Dir))
+	cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive --branch=%s %s %s", r.Depth, branch, r.Path, r.Dir))
 
 	switch {
 	// if a specific commit is provided then we'll

--- a/pkg/build/script/script.go
+++ b/pkg/build/script/script.go
@@ -7,6 +7,7 @@ import (
 	"launchpad.net/goyaml"
 
 	"github.com/drone/drone/pkg/build/buildfile"
+	"github.com/drone/drone/pkg/build/git"
 	"github.com/drone/drone/pkg/plugin/deploy"
 	"github.com/drone/drone/pkg/plugin/notify"
 	"github.com/drone/drone/pkg/plugin/publish"
@@ -54,6 +55,7 @@ type Build struct {
 	Deploy        *deploy.Deploy       `yaml:"deploy,omitempty"`
 	Publish       *publish.Publish     `yaml:"publish,omitempty"`
 	Notifications *notify.Notification `yaml:"notify,omitempty"`
+	Git           *git.Git             `yaml:"git,omitempty"`
 }
 
 // Write adds all the steps to the build script, including

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	bldr "github.com/drone/drone/pkg/build"
+	"github.com/drone/drone/pkg/build/git"
 	r "github.com/drone/drone/pkg/build/repo"
 	"github.com/drone/drone/pkg/build/script"
 	"github.com/drone/drone/pkg/channel"
@@ -135,7 +136,7 @@ func (b *BuildTask) execute() error {
 	// execute the build
 	builder := bldr.Builder{}
 	builder.Build = b.Script
-	builder.Repo = &r.Repo{Path: b.Repo.URL, Branch: b.Commit.Branch, Commit: b.Commit.Hash, PR: b.Commit.PullRequest, Dir: filepath.Join("/var/cache/drone/src", b.Repo.Slug)}
+	builder.Repo = &r.Repo{Path: b.Repo.URL, Branch: b.Commit.Branch, Commit: b.Commit.Hash, PR: b.Commit.PullRequest, Dir: filepath.Join("/var/cache/drone/src", b.Repo.Slug), Depth: git.GitDepth(b.Script.Git)}
 	builder.Key = []byte(b.Repo.PrivateKey)
 	builder.Stdout = buf
 	builder.Timeout = 300 * time.Minute


### PR DESCRIPTION
Implemented a function for developers to specify the --depth option of the git clone command. refs #55

I included the #60 instructions.

I made Git.Depth type `*int` so that we can distinguish the following cases:
- `git: depth:` is not set on .drone.yml. (In this case the default depth value(50) is set to --depth.)
- `git: depth:` is set to 0 on .drone.yml. (In this case 0 is set to --depth.)

```
type Git struct {
   Depth *int `yaml:"depth"`
}
```
