### PR TITLE
Fixup back url in commit status

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -225,7 +225,11 @@ func updateGitHubStatus(repo *Repo, commit *Commit) error {
 	}
 
 	client := github.New(user.GithubToken)
-	return client.Repos.CreateStatus(repo.Owner, repo.Name, status, settings.URL().String(), message, commit.Hash)
+
+	var url string
+	url = settings.URL().String() + "/" + repo.Slug + "/commit/" + commit.Hash
+
+	return client.Repos.CreateStatus(repo.Owner, repo.Name, status, url, message, commit.Hash)
 }
 
 type bufferWrapper struct {


### PR DESCRIPTION
This is fix for back url in commit status:

![2014-02-13 13-08-29 by floatdrop pull request 6 project-stubyandex-environment](https://f.cloud.github.com/assets/365089/2157561/c92f777e-947e-11e3-88f5-bcc81945f7c4.png)
