### PR TITLE
Add a Dockerfile for building Drone.io Docker containers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:13.10
+
+MAINTAINER Drone.io Team
+
+RUN apt-get update
+RUN apt-get install -y wget gcc make g++ build-essential ca-certificates mercurial git bzr libsqlite3-dev sqlite3
+
+RUN wget https://go.googlecode.com/files/go1.2.src.tar.gz && tar zxvf go1.2.src.tar.gz && cd go/src && ./make.bash 
+
+ENV PATH $PATH:/go/bin:/gocode/bin
+ENV GOPATH /gocode
+
+RUN mkdir -p /gocode/src/github.com/drone
+
+ADD . /gocode/src/github.com/drone/drone
+
+WORKDIR /gocode/src/github.com/drone/drone
+
+RUN make deps
+RUN make
+RUN make install
+
+EXPOSE 80
+
+ENTRYPOINT ["/usr/local/bin/droned"]
+
+CMD ["--port=:80", "--path=/var/lib/drone/drone.sqlite"]


### PR DESCRIPTION
With the help/direction of @bradrydzewski and @crosbymichael, I have created the Dockerfile included in this commit.  I've tested this locally and was able to successfully create a Docker container image for Drone and run it using Docker.  This will be a huge help for people wanting to develop/run Drone without being on a Linux box.

I tested this on OS X 10.9.1 using boot2docker 0.5.4 and Docker 0.8.0.
