### PR TITLE
respect DOCKER_HOST

### DIFF
--- a/pkg/build/docker/client_test.go
+++ b/pkg/build/docker/client_test.go
@@ -1,0 +1,67 @@
+package docker
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestHostFromEnv(t *testing.T) {
+	os.Setenv("DOCKER_HOST", "tcp://1.1.1.1:4243")
+	defer os.Setenv("DOCKER_HOST", "")
+
+	client := New()
+
+	if client.proto != "tcp" {
+		t.Fail()
+	}
+
+	if client.addr != "1.1.1.1:4243" {
+		t.Fail()
+	}
+}
+
+func TestInvalidHostFromEnv(t *testing.T) {
+	os.Setenv("DOCKER_HOST", "tcp:1.1.1.1:4243") // missing tcp:// prefix
+	defer os.Setenv("DOCKER_HOST", "")
+
+	client := New()
+
+	if client.addr == "1.1.1.1:4243" {
+		t.Fail()
+	}
+}
+
+func TestSocketHost(t *testing.T) {
+	// create temporary file to represent the docker socket
+	file, err := ioutil.TempFile("", "TestDefaultUnixHost")
+	if err != nil {
+		t.Fail()
+	}
+	file.Close()
+	defer os.Remove(file.Name())
+
+	client := &Client{}
+	client.setHost(file.Name())
+
+	if client.proto != "unix" {
+		t.Fail()
+	}
+
+	if client.addr != file.Name() {
+		t.Fail()
+	}
+}
+
+func TestDefaultTcpHost(t *testing.T) {
+	client := &Client{}
+	client.setHost("/tmp/missing_socket")
+
+	if client.proto != "tcp" {
+		t.Fail()
+	}
+
+	if client.addr != "0.0.0.0:4243" {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
enable use of docker-standard DOCKER_HOST environment variable to allow drone to run builds on remote docker hosts.

`DOCKER_HOST=tcp://dockerhost:4243 drone -v build`
