### PR TITLE
post-build commands, executed outside of the container

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -350,6 +350,17 @@ func (b *Builder) run() error {
 		return err
 	}
 
+	// execute any post-build steps outside of the container
+	for _, command := range b.Build.PostBuild {
+		cmd := exec.Command("/bin/bash", "-c", command)
+		cmd.Env = append(os.Environ(), "CONTAINER_ID="+run.ID)
+		if err = cmd.Run(); err != nil {
+			b.BuildState.ExitCode = 1
+			b.BuildState.Finished = time.Now().UTC().Unix()
+			return err
+		}
+	}
+
 	// set completion time
 	b.BuildState.Finished = time.Now().UTC().Unix()
 

--- a/pkg/build/script/script.go
+++ b/pkg/build/script/script.go
@@ -62,6 +62,8 @@ type Build struct {
 	// linked to the build environment.
 	Services []string
 
+	PostBuild []string `yaml:"post-build,omitempty"`
+
 	Deploy        *deploy.Deploy       `yaml:"deploy,omitempty"`
 	Publish       *publish.Publish     `yaml:"publish,omitempty"`
 	Notifications *notify.Notification `yaml:"notify,omitempty"`


### PR DESCRIPTION
feedback wanted about this feature! thanks!

i was looking for a way to extract build artifacts from the container using the [docker cp](http://docs.docker.io/en/latest/commandline/cli/#cp) command. i was hoping to implement this as a "publisher", but drone currently implements publishers as scripts injected into the container and i didn't want to fundamentally change how they worked.

instead of implementing a "docker cp"-specific setting, i figured that allowing any commands to run after the container has stopped, but before the container is deleted would be useful.  the current implementation only passes in a CONTAINER_ID environment variable.

example:

```
post-build:
  - docker cp $CONTAINER_ID:/tmp/myapp.tgz /builds/myapp/
```
