### PR TITLE
logline output buffers rather than updating on every ws message

### DIFF
--- a/pkg/template/pages/repo_commit.html
+++ b/pkg/template/pages/repo_commit.html
@@ -133,13 +133,36 @@
 		outputWS.onopen = function () { console.log('output websocket open'); };
 		outputWS.onerror = function (e) { console.log('websocket error: ' + e); };
 		outputWS.onclose = function (e) { window.location.reload(); };
-		outputWS.onmessage = function (e) { 
-			outputBox.innerHTML += formatLine(e.data);
-			if (window.autofollow) {
-				window.scrollTo(0, document.body.scrollHeight);
-			}
+
+		window.requestAnimationFrame = window.requestAnimationFrame ||
+			window.webkitRequestAnimationFrame ||
+			function(callback, element) {
+				return window.setTimeout(function() {
+					callback(+new Date());
+				}, 1000 / 60);
+			};
+
+		var lineBuffer = "";
+
+		outputWS.onmessage = function (e) {
+			lineBuffer += formatLine(e.data);
 		};
-	{{ else }} 
+
+		function updateScreen() {
+			if(lineBuffer.length > 0) {
+				outputBox.innerHTML += lineBuffer;
+				lineBuffer = '';
+
+				if (window.autofollow) {
+					window.scrollTo(0, document.body.scrollHeight);
+				}
+			}
+			requestAnimationFrame(updateScreen);
+		}
+
+		requestAnimationFrame(updateScreen);
+
+	{{ else }}
 		$.get("/{{ .Repo.Slug }}/commit/{{ .Commit.Hash }}/build/{{ .Build.Slug }}/out.txt", function( data ) {
 			$( "#stdout" ).html(formatLine(data));
 		});


### PR DESCRIPTION
In builds with lots of output, trying to reload the page partway through the build results in thousands of websocket messages (one per line) that each update the DOM.  This can cause the browser to freeze.  Instead, use requestAnimation frame to delay the DOM updates.

I think this may fix at least one issue that lead to https://github.com/drone/drone/issues/120.

The amount of inline javascript may get unwieldy at some point.  Would you consider a separate pull request to move it out into its own file?
