### PR TITLE
Fix gravatar size at build page to fit the stylesheet.

### DIFF
--- a/pkg/model/commit.go
+++ b/pkg/model/commit.go
@@ -34,7 +34,7 @@ func (c *Commit) HashShort() string {
 }
 
 // Returns the Gravatar Image URL.
-func (c *Commit) Image() string      { return fmt.Sprintf(GravatarPattern, c.Gravatar, 42) }
+func (c *Commit) Image() string      { return fmt.Sprintf(GravatarPattern, c.Gravatar, 58) }
 func (c *Commit) ImageSmall() string { return fmt.Sprintf(GravatarPattern, c.Gravatar, 32) }
 func (c *Commit) ImageLarge() string { return fmt.Sprintf(GravatarPattern, c.Gravatar, 160) }
 


### PR DESCRIPTION
Minor re-styling, the commit build page has gravatar size fixed at css to 58px, but the url hardcoded to provide 42px image, change it to 58px so it's not upscaled by browser. Now it looks better.
