### PR TITLE
Implement `branch` option at deploy.

### DIFF
--- a/pkg/plugin/deploy/ssh.go
+++ b/pkg/plugin/deploy/ssh.go
@@ -63,11 +63,13 @@ func (s *SSH) Write(f *buildfile.Buildfile) {
 		}
 	}
 
-	if len(s.Artifacts) > 1 && !artifact {
-		artifact = compress(f, s.Artifacts)
-	} else if len(s.Artifacts) == 1 {
-		f.WriteCmdSilent(fmt.Sprintf("ARTIFACT=%s", s.Artifacts[0]))
-		artifact = true
+	if !artifact {
+		if len(s.Artifacts) > 1 {
+			artifact = compress(f, s.Artifacts)
+		} else if len(s.Artifacts) == 1 {
+			f.WriteCmdSilent(fmt.Sprintf("ARTIFACT=%s", s.Artifacts[0]))
+			artifact = true
+		}
 	}
 
 	if artifact {

--- a/pkg/plugin/deploy/ssh_test.go
+++ b/pkg/plugin/deploy/ssh_test.go
@@ -119,6 +119,10 @@ func TestSSHGitArchive(t *testing.T) {
 		t.Errorf("Expect script to contains artifact")
 	}
 
+	if strings.Contains(bscr, "=GITARCHIVE") {
+		t.Errorf("Doesn't expect script to contains GITARCHIVE literals")
+	}
+
 	if !strings.Contains(bscr, "git archive --format=tar.gz --prefix=${PWD##*/}/ ${COMMIT} > ${ARTIFACT}") {
 		t.Errorf("Expect script to run git archive")
 	}


### PR DESCRIPTION
Enable deployment only on specific branch.
The branch checking is implemented inside the build shell-script by wrapping deployment
code inside a function and then match the value of `branch` option with `DRONE_BRANCH` before executing the function.

As always, any inputs is more than welcome.

Thanks!
