### PR TITLE
Add optional `--name` argument to `drone build` command

### DIFF
--- a/cmd/drone/drone.go
+++ b/cmd/drone/drone.go
@@ -24,6 +24,9 @@ var (
 	// into the container if specified
 	identity = flag.String("identity", "", "")
 
+	// override the default name
+	override_name = flag.String("name", "", "")
+
 	// runs Drone in parallel mode if True
 	parallel = flag.Bool("parallel", false, "")
 
@@ -135,8 +138,16 @@ func run(path string) {
 
 	// get the repository root directory
 	dir := filepath.Dir(path)
+
+	rname := dir
+
+	if len(*override_name) != 0 {
+		log.Infof("using provided repo name: %s", rname)
+		rname = *override_name
+	}
+
 	code := repo.Repo{
-		Name:   dir,
+		Name:   rname,
 		Branch: "HEAD", // should we do this?
 		Path:   dir,
 	}


### PR DESCRIPTION
We have a home-grown CI system that handles taking commit hooks and kicking off test runs via either local scripts or Test Kitchen, and eventually I would love to be able to replace it entirely with drone.  

In the meantime, though, I was to integrate the drone command as a builder for apps with service dependencies.  With the new caching code to speed up bundles, `drone build` seems like it will work great for us.  

Our system, though, clones the repo into a temporary directly for each checkout. That means our directory name is arbitrary and not consistent for sequential builds.  This pull request adds a `--name` argument to `drone build`, allowing us to specify a `Repo.Name` instead setting it to the directory path. If `--name` isn't provided, we just use the directory path as before.

Does this seem like a sensible approach?
