### PR TITLE
support for git branch promotion strategies

### DIFF
--- a/pkg/plugin/deploy/git.go
+++ b/pkg/plugin/deploy/git.go
@@ -6,9 +6,10 @@ import (
 )
 
 type Git struct {
-	Target string `yaml:"target,omitempty"`
-	Force  bool   `yaml:"force,omitempty"`
-	Branch string `yaml:"branch,omitempty"`
+	Target   string            `yaml:"target,omitempty"`
+	Force    bool              `yaml:"force,omitempty"`
+	Branch   string            `yaml:"branch,omitempty"`
+	Branches map[string]string `yaml:"branches,omitempty"`
 }
 
 func (g *Git) Write(f *buildfile.Buildfile) {
@@ -23,9 +24,10 @@ func (g *Git) Write(f *buildfile.Buildfile) {
 	// add target as a git remote
 	f.WriteCmd(fmt.Sprintf("git remote add deploy %s", g.Target))
 
-	destinationBranch := g.Branch
-	if destinationBranch == "" {
-		destinationBranch = "master"
+	branches := g.Branches
+
+	if g.Branch != "" {
+		branches[g.Branch] = g.Branch
 	}
 
 	switch g.Force {
@@ -34,10 +36,15 @@ func (g *Git) Write(f *buildfile.Buildfile) {
 		// by the build script, such as less files converted to css,
 		// that need to be deployed to git remote.
 		f.WriteCmd(fmt.Sprintf("git add -A"))
-		f.WriteCmd(fmt.Sprintf("git commit -m 'add build artifacts'"))
-		f.WriteCmd(fmt.Sprintf("git push deploy $COMMIT:%s --force", destinationBranch))
+		f.WriteCmd(fmt.Sprintf("git commit --amend --reset-author -C HEAD"))
+
+		for src, dest := range branches {
+			f.WriteCmd(fmt.Sprintf(`[ "$DRONE_BRANCH" = "%s" ] && git push deploy HEAD:refs/heads/%s --force`, src, dest))
+		}
 	case false:
 		// otherwise we just do a standard git push
-		f.WriteCmd(fmt.Sprintf("git push deploy $COMMIT:%s", destinationBranch))
+		for src, dest := range branches {
+			f.WriteCmd(fmt.Sprintf(`[ "$DRONE_BRANCH" = "%s" ] && git push deploy $COMMIT:%s"`, src, dest))
+		}
 	}
 }


### PR DESCRIPTION
This allows drone to be used as a pseudo-git-pipeline; the deploy step
specifies branches to promote from and to. For example, `master: passed`
instructs the deploy step to promote to `passed` if we're the `master` branch
and just went green.

The way --force behaves with this as we implemented it may seem weird. I'm not sure it actually worked before; it would make a commit and then just push the original commit to the branch. This changes it to simply amend the previous commit and force-push as a new SHA (otherwise drone will just show the same build, as the uniqueness is SHA1+Repo, not SHA1+Branch+Repo).

Example:

``` yaml
deploy:
  git:
    target: <some-url>
    force: true
    branches:
      master: passed-integration
      passed-integration: passed-deploy
```
