### PR TITLE
set num of workers using command line params

### DIFF
--- a/cmd/droned/drone.go
+++ b/cmd/droned/drone.go
@@ -49,6 +49,10 @@ var (
 
 	// commit sha for the current build.
 	version string
+
+	// Number of concurrent build workers to run
+	// default to number of CPUs on machine
+	workers int
 )
 
 func main() {
@@ -60,6 +64,7 @@ func main() {
 	flag.StringVar(&sslcert, "sslcert", "", "")
 	flag.StringVar(&sslkey, "sslkey", "", "")
 	flag.DurationVar(&timeout, "timeout", 300*time.Minute, "")
+	flag.IntVar(&workers, "workers", runtime.NumCPU(), "")
 	flag.Parse()
 
 	// validate the TLS arguments
@@ -135,7 +140,7 @@ func setupStatic() {
 // setup routes for serving dynamic content.
 func setupHandlers() {
 	queueRunner := queue.NewBuildRunner(docker.New(), timeout)
-	queue := queue.Start(runtime.NumCPU(), queueRunner)
+	queue := queue.Start(workers, queueRunner)
 
 	hookHandler := handler.NewHookHandler(queue)
 

--- a/deb/drone/etc/default/drone
+++ b/deb/drone/etc/default/drone
@@ -6,5 +6,6 @@
 #   -driver="sqlite3":
 #   -path="":
 #   -port=":8080":
+#   -workers="4":
 #         
 #DRONED_OPTS="--port=:80"


### PR DESCRIPTION
Drone currently uses the number of CPUs available on the instance/container/machine that it is running on as the number of concurrent test workers to run. This does not work in cases where the `DOCKER_HOST` is set to be a different instance than the one `droned` is running on. 
