### PR TITLE
Add OpenStack swift publish functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ publish:
     source: /tmp/drone.deb
     target: latest/
 
+  swift:
+    username: someuser
+    password: 030e39a1278a18828389b194b93211aa
+    auth_url: https://identity.api.rackspacecloud.com/v2.0
+    region: DFW
+    container: drone
+    source: /tmp/drone.deb
+    target: latest/drone.deb
+
 ```
 
 Drone currently has these `deploy` and `publish` plugins implemented (more to come!):
@@ -235,6 +244,7 @@ Drone currently has these `deploy` and `publish` plugins implemented (more to co
 
 **publish**
 - [Amazon s3](#docs)
+- [OpenStack Swift](#docs)
 
 ### Notifications
 

--- a/pkg/plugin/publish/publish.go
+++ b/pkg/plugin/publish/publish.go
@@ -9,10 +9,14 @@ import (
 // a Build has succeeded
 type Publish struct {
 	S3 *S3 `yaml:"s3,omitempty"`
+	Swift *Swift `yaml:"swift,omitempty"`
 }
 
 func (p *Publish) Write(f *buildfile.Buildfile) {
 	if p.S3 != nil {
 		p.S3.Write(f)
+	}
+	if p.Swift != nil {
+		p.Swift.Write(f)
 	}
 }

--- a/pkg/plugin/publish/swift.go
+++ b/pkg/plugin/publish/swift.go
@@ -1,0 +1,60 @@
+package publish
+
+import (
+	"fmt"
+
+	"github.com/drone/drone/pkg/build/buildfile"
+)
+
+type Swift struct {
+	// Username for authentication
+	Username string `yaml:"username,omitempty"`
+
+	// Password for authentication
+	// With Rackspace this is usually an API Key
+	Password string `yaml:"password,omitempty"`
+
+	// Container to upload files to
+	Container string `yaml:"container,omitempty"`
+
+	// Base API version URL to authenticate against
+	// Rackspace: https://identity.api.rackspacecloud.com/v2.0
+	AuthURL string `yaml:"auth_url,omitempty"`
+
+	// Region to communicate with, in a generic OpenStack install
+	// this may be RegionOne
+	Region string `yaml:"region,omitempty"`
+
+	// Source file or directory to upload, if source is a directory,
+	// upload the contents of the directory
+	Source string `yaml:"source,omitempty"`
+
+	// Destination to write the file(s) to. Should contain the full
+	// object name if source is a file
+	Target string `yaml:"target,omitempty"`
+
+	Branch string `yaml:"branch,omitempty"`
+}
+
+func (s *Swift) Write(f *buildfile.Buildfile) {
+	// All options are required, so ensure they are present
+	if len(s.Username) == 0 || len(s.Password) == 0 || len(s.AuthURL) == 0 || len(s.Region) == 0 || len(s.Source) == 0 || len(s.Container) == 0 || len(s.Target) == 0 {
+		f.WriteCmdSilent(`echo "Swift: Missing argument(s)"`)
+		return
+	}
+
+	// debugging purposes so we can see if / where something is failing
+	f.WriteCmdSilent(`echo "Swift: Publishing..."`)
+
+	// install swiftly using PIP
+	f.WriteCmdSilent("[ -f /usr/bin/sudo ] || pip install swiftly 1> /dev/null 2> /dev/null")
+	f.WriteCmdSilent("[ -f /usr/bin/sudo ] && sudo pip install swiftly 1> /dev/null 2> /dev/null")
+
+	// Write out environment variables
+	f.WriteEnv("SWIFTLY_AUTH_URL", s.AuthURL)
+	f.WriteEnv("SWIFTLY_AUTH_USER", s.Username)
+	f.WriteEnv("SWIFTLY_AUTH_KEY", s.Password)
+	f.WriteEnv("SWIFTLY_REGION", s.Region)
+
+	f.WriteCmd(fmt.Sprintf(`swiftly put -i %s %s/%s`, s.Source, s.Container, s.Target))
+}


### PR DESCRIPTION
This pull request adds OpenStack Swift support as a publish method, which will also support Rackspace Cloud Files.

An example use for Rackspace Public Cloud would look like:

```
  swift:
    username: someuser
    password: 030e39a1278a18828389b194b93211aa
    auth_url: https://identity.api.rackspacecloud.com/v2.0
    region: DFW
    container: drone
    source: /tmp/drone.deb
    target: latest/drone.deb
```
