### PR TITLE
run privileged builds in web workers

### DIFF
--- a/pkg/queue/build_runner.go
+++ b/pkg/queue/build_runner.go
@@ -11,7 +11,7 @@ import (
 )
 
 type BuildRunner interface {
-	Run(buildScript *script.Build, repo *repo.Repo, key []byte, buildOutput io.Writer) (success bool, err error)
+	Run(buildScript *script.Build, repo *repo.Repo, key []byte, privileged bool, buildOutput io.Writer) (success bool, err error)
 }
 
 type buildRunner struct {
@@ -26,11 +26,12 @@ func NewBuildRunner(dockerClient *docker.Client, timeout time.Duration) BuildRun
 	}
 }
 
-func (runner *buildRunner) Run(buildScript *script.Build, repo *repo.Repo, key []byte, buildOutput io.Writer) (bool, error) {
+func (runner *buildRunner) Run(buildScript *script.Build, repo *repo.Repo, key []byte, privileged bool, buildOutput io.Writer) (bool, error) {
 	builder := build.New(runner.dockerClient)
 	builder.Build = buildScript
 	builder.Repo = repo
 	builder.Key = key
+	builder.Privileged = privileged
 	builder.Stdout = buildOutput
 	builder.Timeout = runner.timeout
 

--- a/pkg/queue/worker.go
+++ b/pkg/queue/worker.go
@@ -183,6 +183,7 @@ func (w *worker) runBuild(task *BuildTask, buf io.Writer) (bool, error) {
 		task.Script,
 		repo,
 		[]byte(task.Repo.PrivateKey),
+		task.Repo.Privileged,
 		buf,
 	)
 }


### PR DESCRIPTION
Looks like this got lost in the merging - we don't actually run the builds marked privileged, privileged. Unfortunately the queue package doesn't have any tests, and it may be tricky to start rolling them in as there's a lot of interleaved logic/etc.

Normally we'd add a test to cover this, either at the unit level or integration level if that's a thing.  If you want to stand up a test suite for this component we'd be happy to help flesh it out, but we're not sure what testing approach you want to take, so we didn't feel confident starting the process.
