### PR TITLE
Provide checkbox to override private setting on repo

### DIFF
--- a/pkg/handler/repos.go
+++ b/pkg/handler/repos.go
@@ -328,7 +328,7 @@ func RepoUpdate(w http.ResponseWriter, r *http.Request, u *User, repo *Repo) err
 	default:
 		repo.Disabled = len(r.FormValue("Disabled")) == 0
 		repo.DisabledPullRequest = len(r.FormValue("DisabledPullRequest")) == 0
-
+		repo.Private = len(r.FormValue("Private")) > 0
 		repo.Privileged = u.Admin && len(r.FormValue("Privileged")) > 0
 
 		// value of "" indicates the currently authenticated user

--- a/pkg/template/pages/repo_settings.html
+++ b/pkg/template/pages/repo_settings.html
@@ -31,7 +31,7 @@
 		<div class="col-xs-9" role="main">
 			<div class="alert">Manage your repository settings.</div>
 				<form method="POST" action="/{{.Repo.Slug}}" role="form">
-					<div class="checkbox">
+					<div class="checkbox form-group">
 						<label>
 							<input class="" type="checkbox" name="Disabled" {{ if not .Repo.Disabled }}checked="True" {{ end }}/>
 							Enable Build Hooks
@@ -41,6 +41,12 @@
 						<label>
 							<input class="" type="checkbox" name="DisabledPullRequest" {{ if not .Repo.DisabledPullRequest }}checked="True" {{ end }}/>
 							Enable Pull Hooks
+						</label>
+					</div>
+					<div class="checkbox form-group">
+						<label>
+							<input class="" type="checkbox" name="Private" {{ if .Repo.Private }}checked="True" {{ end }}/>
+							Private
 						</label>
 					</div>
 					{{ if .User.Admin }}


### PR DESCRIPTION
We have a need to configure "public" repos within drone to be 'private' so that build results are not publicly viewable.  The reason for this is the integration testing we do, has the potential of exposing sensitive information during a failure.

We were able to achieve the required results, by manipulating the database directly, however I figured it would be better to have a checkbox to manipulate this setting.
