### PR TITLE
Fix repo keys get truncated if mysql is used

### DIFF
--- a/cmd/droned/drone.go
+++ b/cmd/droned/drone.go
@@ -231,6 +231,7 @@ func setupHandlers() {
 	m.Get("/:host/:owner/:name/params", handler.RepoAdminHandler(handler.RepoParamsForm))
 	m.Get("/:host/:owner/:name/badges", handler.RepoAdminHandler(handler.RepoBadges))
 	m.Get("/:host/:owner/:name/keys", handler.RepoAdminHandler(handler.RepoKeys))
+	m.Post("/:host/:owner/:name/keys", handler.RepoAdminHandler(handler.RepoRegenerateKeys))
 	m.Get("/:host/:owner/:name/delete", handler.RepoAdminHandler(handler.RepoDeleteForm))
 	m.Post("/:host/:owner/:name/delete", handler.RepoAdminHandler(handler.RepoDelete))
 	m.Get("/:host/:owner/:name", handler.RepoHandler(handler.RepoDashboard))

--- a/pkg/database/migrate/20140409095256_change_privkey_use_text.go
+++ b/pkg/database/migrate/20140409095256_change_privkey_use_text.go
@@ -1,0 +1,73 @@
+package migrate
+
+import (
+	"database/sql"
+	"encoding/pem"
+	"log"
+)
+
+type rev20140409095256 struct{}
+
+type privekeynslug struct {
+	PrivateKey string
+	Slug       string
+}
+
+var ChangePrivkeyUseText = &rev20140409095256{}
+
+func (r *rev20140409095256) Revision() int64 {
+	return 20140409095256
+}
+
+func (r *rev20140409095256) Up(mg *MigrationDriver) error {
+	if _, err := mg.ChangeColumn("repos", "private_key", "TEXT"); err != nil {
+		return err
+	}
+
+	pks, err := fetchPrivateKeys(mg)
+	if err != nil {
+		return err
+	}
+
+	var ec int
+	for _, pk := range pks {
+		// Check if we can decode existing private key
+		block, _ := pem.Decode([]byte(pk.PrivateKey))
+		if block == nil {
+			ec += 1
+			log.Printf("Private key broken for: %s\n", pk.Slug)
+		}
+	}
+	log.Printf("%d errors, %d keys total\n", ec, len(pks))
+
+	return err
+}
+
+func (r *rev20140409095256) Down(mg *MigrationDriver) error {
+	_, err := mg.ChangeColumn("repos", "private_key", "VARCHAR(1024)")
+	return err
+}
+
+func fetchPrivateKeys(mg *MigrationDriver) ([]privekeynslug, error) {
+	var result []privekeynslug
+	rows, err := mg.Tx.Query(`select slug, private_key from repos`)
+	if err != nil {
+
+		return result, err
+	}
+	for rows.Next() {
+		var slug, pk sql.NullString
+		if err := rows.Scan(&slug, &pk); err != nil {
+			return result, err
+		}
+		pks := privekeynslug{}
+		if slug.Valid {
+			pks.Slug = slug.String
+		}
+		if pk.Valid {
+			pks.PrivateKey = pk.String
+		}
+		result = append(result, pks)
+	}
+	return result, err
+}

--- a/pkg/database/migrate/all.go
+++ b/pkg/database/migrate/all.go
@@ -13,6 +13,7 @@ func (m *Migration) All() *Migration {
 	m.Add(GitHubEnterpriseSupport)
 	m.Add(AddOpenInvitationColumn)
 	m.Add(AddGitlabColumns)
+	m.Add(ChangePrivkeyUseText)
 
 	// m.Add(...)
 	// ...

--- a/pkg/handler/repos.go
+++ b/pkg/handler/repos.go
@@ -317,6 +317,19 @@ func RepoKeys(w http.ResponseWriter, r *http.Request, u *User, repo *Repo) error
 	return RenderTemplate(w, "repo_keys.html", &data)
 }
 
+func RepoRegenerateKeys(w http.ResponseWriter, r * http.Request, u *User, repo *Repo) error {
+	if err := repo.AddKeyPair(); err != nil {
+		return fmt.Errorf("Unable to regenerate key pairs: %q", err)
+	}
+
+	if err := database.SaveRepo(repo); err != nil {
+		return err
+	}
+
+	http.Redirect(w, r, r.URL.Path, http.StatusSeeOther)
+	return nil
+}
+
 // Updates an existing repository.
 func RepoUpdate(w http.ResponseWriter, r *http.Request, u *User, repo *Repo) error {
 	switch r.FormValue("action") {

--- a/pkg/template/pages/repo_keys.html
+++ b/pkg/template/pages/repo_keys.html
@@ -28,13 +28,20 @@
 				</ul>
 			</div><!-- ./col-xs-3 -->
 
-			<div class="col-xs-9" role="main">
-				<div class="alert">Public Key, used for Deployments</div>
-				<form>
-					<label>You can add this Key to your Heroku account, SSH <code>.ssh/authorized_keys</code> file, and more.</label>
+			<div class="col-xs-9" role="main"><div class="alert">Public Key, used for Deployments</div>
+				<form method="POST" action="/{{.Repo.Slug}}/keys">
+					<label>You can add this Key to your Heroku account, SSH <code>.ssh/authorized_keys</code> file, and more. Drone also use this key to fetch private repositories.</label>
 					<div>
 						<textarea name="PublicKey" class="form-control" rows="8" spellcheck="false">{{.Repo.PublicKey}}</textarea>
 					</div>
+
+					<div class="form-actions">
+						{{if .Repo.Private }}
+						<label>This repository is private.<br>You may have to manually add the new public key to your upstream host if you regenerate them here.</label>
+						{{end}}
+						<input class="btn btn-primary" id="submitButton" type="submit" value="Regenerate Key">
+					</div>
+
 				</form>
 			</div><!-- ./col-xs-9 -->
 		</div><!-- ./row -->


### PR DESCRIPTION
I've mentioned this somewhere before. SQlite has no restriction checking on its column type and length. So basically you can specify a column as any type, and insert any value, no complaint.

It's going to be a problem when we migrate the database into mysql or any other server. In this case, 1024 for key length is not sufficient, and using multi-bytes collation will make that even worse.

Change the column type to BLOB and check for truncated keys, any error key will be logged but should manually regenerated.

Also add feature to regenerate key pairs for repository via repo settings page.

Thanks.
