### PR TITLE
Deploy to cloudfoundry

### DIFF
--- a/pkg/plugin/deploy/cloudfoundry.go
+++ b/pkg/plugin/deploy/cloudfoundry.go
@@ -16,6 +16,13 @@ type CloudFoundry struct {
 }
 
 func (cf *CloudFoundry) Write(f *buildfile.Buildfile) {
+    downloadCmd := "curl -sLO http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-cli_amd64.deb"
+    installCmd  := "dpkg -i cf-cli_amd64.deb 1> /dev/null 2> /dev/null"
+
+    // download and install the cf tool
+    f.WriteCmdSilent(fmt.Sprintf("[ -f /usr/bin/sudo ] && sudo %s || %s", downloadCmd, downloadCmd))
+    f.WriteCmdSilent(fmt.Sprintf("[ -f /usr/bin/sudo ] && sudo %s || %s", installCmd, installCmd))
+
     // login
     loginCmd := "cf login -a %s -u %s -p %s"
 

--- a/pkg/plugin/deploy/cloudfoundry_test.go
+++ b/pkg/plugin/deploy/cloudfoundry_test.go
@@ -61,6 +61,21 @@ func setUpWithCF(input string) (string, error) {
     return bf.String(), err
 }
 
+func TestCloudFoundryToolInstall(t *testing.T) {
+    bscr, err := setUpWithCF(sampleYmlBasic)
+    if err != nil {
+        t.Fatalf("Can't unmarshal deploy script: %s", err)
+    }
+
+    if !strings.Contains(bscr, "curl -sLO http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-cli_amd64.deb") {
+        t.Error("Expect script to contain download command")
+    }
+
+    if !strings.Contains(bscr, "dpkg -i cf-cli_amd64.deb") {
+        t.Error("Expect script to contain install command")
+    }
+}
+
 func TestCloudFoundryDeployment(t *testing.T) {
     bscr, err := setUpWithCF(sampleYmlBasic)
     if err != nil {
@@ -68,11 +83,11 @@ func TestCloudFoundryDeployment(t *testing.T) {
     }
 
     if !strings.Contains(bscr, "cf login -a https://api.example.com -u foo -p bar") {
-        t.Error("Expect login script to contains username and password")
+        t.Error("Expect login script to contain username and password")
     }
 
     if !strings.Contains(bscr, "cf push") {
-        t.Error("Expect script to contains push")
+        t.Error("Expect script to contain push")
     }
 }
 
@@ -83,7 +98,7 @@ func TestCloudFoundryDeploymentWithOrg(t *testing.T) {
     }
 
     if !strings.Contains(bscr, "cf login -a https://api.example.com -u foo -p bar -o custom-org") {
-        t.Error("Expect login script to contains organization")
+        t.Error("Expect login script to contain organization")
     }
 }
 
@@ -94,7 +109,7 @@ func TestCloudFoundryDeploymentWithSpace(t *testing.T) {
     }
 
     if !strings.Contains(bscr, "cf login -a https://api.example.com -u foo -p bar -o custom-org -s dev") {
-        t.Error("Expect login script to contains space")
+        t.Error("Expect login script to contain space")
     }
 }
 
@@ -105,6 +120,6 @@ func TestCloudFoundryDeploymentWithApp(t *testing.T) {
     }
 
     if !strings.Contains(bscr, "cf push test-app") {
-        t.Error("Expect login script to contains app name")
+        t.Error("Expect login script to contain app name")
     }
 }


### PR DESCRIPTION
This is for issue #193.
It requires `cf` cli tool installed inside the container. so a working configuration in `.drone.yml` is:

```
image: node:0.10
name: example-app
script:
  - npm config set ca ""
  - npm install
  # install cf tools
  - curl -O https://console.run.pivotal.io/downloads/cf-cli_amd64.deb
  - dpkg -i cf-cli_amd64.deb

deploy:
  cloudfoundry:
    target: https://api.run.pivotal.io
    username: <username>
    password: <pwd>
```
