### PR TITLE
Set the width on user dashboard commit-summary

### DIFF
--- a/cmd/droned/assets/css/drone.css
+++ b/cmd/droned/assets/css/drone.css
@@ -1,4 +1,4 @@
-body {
+﻿body {
   background: #FFF;
 }
 .container {
@@ -894,15 +894,16 @@ pre {
 }
 .build-details img {
   float: left;
-  border-radius: 50%;
   -webkit-border-radius: 50%;
   -moz-border-radius: 50%;
+  border-radius: 50%;
   margin-right: 30px;
   width: 58px;
   height: 58px;
 }
 .build-details .commit-summary {
   float: left;
+  width: 500px;
 }
 .build-details .commit-summary dd {
   overflow: hidden;

--- a/cmd/droned/assets/css/drone.less
+++ b/cmd/droned/assets/css/drone.less
@@ -1047,9 +1047,9 @@ pre {
 
         img {
                 float:left;
-                    border-radius:50%;
-      -webkit-border-radius:50%;
-        -moz-border-radius:50%;
+				-webkit-border-radius:50%;
+				-moz-border-radius:50%;
+                border-radius:50%;
                 margin-right: 30px;
                 width: 58px;
                 height: 58px;
@@ -1057,6 +1057,7 @@ pre {
 
         .commit-summary {
                 float:left;
+				width: 500px;
 
                 dd {
                 	overflow: hidden;


### PR DESCRIPTION
So text is not unnecessarily cut off - particularly in Firefox.

This is the CSS only portion of the larger PR that had the JS changes for timeago.
