### PR TITLE
Updated Godeps as build was failing

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -53,6 +53,14 @@
 			"Rev": "387fd3d63f391b3155205bdc6cc089b0741273df"
 		},
 		{
+			"ImportPath": "github.com/GeertJohan/go.incremental",
+			"Rev": "92fd0ce4a694213e8b3dfd2d39b16e51d26d0fbf"
+		},
+		{
+			"ImportPath": "github.com/jessevdk/go-flags",
+			"Rev": "cee4db96aec1f7382a0b09d8249c09a8bb8d160b"
+		},
+		{
 			"ImportPath": "github.com/andybons/hipchat",
 			"Rev": "3276a607ebc8e1fe4013eeeca921b9ef72387b02"
 		},


### PR DESCRIPTION
Build was failing 

$make
cd cmd/droned/assets && find js -name "_.js" ! -name '._' ! -name "main.js" -exec cat {} \; > js/main.js
go install github.com/GeertJohan/go.rice/rice
../../GeertJohan/go.rice/rice/identifier.go:4:2: cannot find package "github.com/GeertJohan/go.incremental" in any of:
    /go/src/pkg/github.com/GeertJohan/go.incremental (from $GOROOT)
    /gocode/src/github.com/GeertJohan/go.incremental (from $GOPATH)
../../GeertJohan/go.rice/rice/flags.go:5:2: cannot find package "github.com/jessevdk/go-flags" in any of:
    /go/src/pkg/github.com/jessevdk/go-flags (from $GOROOT)
    /gocode/src/github.com/jessevdk/go-flags (from $GOPATH)
make: **\* [rice] Error 1
