### PR TITLE
Add the ability to restrict publish plugins to a specific branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ publish:
     container: drone
     source: /tmp/drone.deb
     target: latest/drone.deb
+    branch: master
 
 ```
 
@@ -247,6 +248,10 @@ Drone currently has these `deploy` and `publish` plugins implemented (more to co
 - [Amazon s3](#docs)
 - [OpenStack Swift](#docs)
 - [PyPI](#docs)
+
+Publish plugins can be limited to a specific branch using the `branch` configuration
+as seen above in the `swift` example. If you do not specify a `branch` all branches
+will be published, with the exception of Pull Requests.
 
 ### Notifications
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -517,7 +517,7 @@ func (b *Builder) writeBuildScript(dir string) error {
 	// we should only execute the build commands,
 	// and omit the deploy and publish commands.
 	if len(b.Repo.PR) == 0 {
-		b.Build.Write(f)
+		b.Build.Write(f, b.Repo)
 	} else {
 		// only write the build commands
 		b.Build.WriteBuild(f)

--- a/pkg/build/script/script.go
+++ b/pkg/build/script/script.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/drone/drone/pkg/build/buildfile"
 	"github.com/drone/drone/pkg/build/git"
+	"github.com/drone/drone/pkg/build/repo"
 	"github.com/drone/drone/pkg/plugin/deploy"
 	"github.com/drone/drone/pkg/plugin/notify"
 	"github.com/drone/drone/pkg/plugin/publish"
@@ -81,13 +82,13 @@ type Build struct {
 
 // Write adds all the steps to the build script, including
 // build commands, deploy and publish commands.
-func (b *Build) Write(f *buildfile.Buildfile) {
+func (b *Build) Write(f *buildfile.Buildfile, r *repo.Repo) {
 	// append build commands
 	b.WriteBuild(f)
 
 	// write publish commands
 	if b.Publish != nil {
-		b.Publish.Write(f)
+		b.Publish.Write(f, r)
 	}
 
 	// write deployment commands

--- a/pkg/plugin/publish/publish.go
+++ b/pkg/plugin/publish/publish.go
@@ -2,6 +2,7 @@ package publish
 
 import (
 	"github.com/drone/drone/pkg/build/buildfile"
+	"github.com/drone/drone/pkg/build/repo"
 )
 
 // Publish stores the configuration details
@@ -13,14 +14,19 @@ type Publish struct {
 	PyPI  *PyPI  `yaml:"pypi,omitempty"`
 }
 
-func (p *Publish) Write(f *buildfile.Buildfile) {
-	if p.S3 != nil {
+func (p *Publish) Write(f *buildfile.Buildfile, r *repo.Repo) {
+	// S3
+	if p.S3 != nil && (len(p.S3.Branch) == 0 || (len(p.S3.Branch) > 0 && r.Branch == p.S3.Branch)) {
 		p.S3.Write(f)
 	}
-	if p.Swift != nil {
+
+	// Swift
+	if p.Swift != nil && (len(p.Swift.Branch) == 0 || (len(p.Swift.Branch) > 0 && r.Branch == p.Swift.Branch)) {
 		p.Swift.Write(f)
 	}
-	if p.PyPI != nil {
+
+	// PyPI
+	if p.PyPI != nil && (len(p.PyPI.Branch) == 0 || (len(p.PyPI.Branch) > 0 && r.Branch == p.PyPI.Branch)) {
 		p.PyPI.Write(f)
 	}
 }

--- a/pkg/plugin/publish/pypi.go
+++ b/pkg/plugin/publish/pypi.go
@@ -2,6 +2,7 @@ package publish
 
 import (
 	"fmt"
+
 	"github.com/drone/drone/pkg/build/buildfile"
 )
 
@@ -36,6 +37,7 @@ type PyPI struct {
 	Password   string   `yaml:"password,omitempty"`
 	Formats    []string `yaml:"formats,omitempty"`
 	Repository string   `yaml:"repository,omitempty"`
+	Branch     string   `yaml:"branch,omitempty"`
 }
 
 func (p *PyPI) Write(f *buildfile.Buildfile) {


### PR DESCRIPTION
This pull request adds the ability to restrict running publish plugins to a specific branch.  This functionality uses the unused `branch` option that the s3 and swift plugins had already defined.  Additionally the option was extended to the PyPI plugin.

An example would be only wanting to publish a file after a successful build/test to the `master` branch.  Existing functionality remains unchanged, running publish plugins on all branches if `branch` is not specified.

An example would look like:

```
publish:
  swift:
    username: someuser
    password: 030e39a1278a18828389b194b93211aa
    auth_url: https://identity.api.rackspacecloud.com/v2.0
    region: DFW
    container: drone
    source: /tmp/drone.deb
    target: latest/drone.deb
    branch: master
```

In addition to this change, since `*repo.Repo` is passed down to `publish.Publish.Write` publish plugins in the future could utilize all information provided by the Repo struct by passing it in to the individual plugins `Write` method.

This could also be extended to deployment plugins, etc...I don't have a use case at the moment outside of publish plugins, so for now I've restricted it to that.
