### PR TITLE
Support custom PyPI repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Drone currently has these `deploy` and `publish` plugins implemented (more to co
 **publish**
 - [Amazon s3](#docs)
 - [OpenStack Swift](#docs)
+- [PyPI](#docs)
 
 ### Notifications
 

--- a/pkg/plugin/publish/pypi.go
+++ b/pkg/plugin/publish/pypi.go
@@ -10,17 +10,18 @@ var pypirc = `
 cat <<EOF > $HOME/.pypirc
 [distutils]
 index-servers = 
-    pypi
+    %s
 
-[pypi]
+[%s]
 username:%s
 password:%s
+%s
 EOF`
 
 var deployCmd = `
-if [ -z $_PYPI_SETUP_PY ]
+if [ -n "$_PYPI_SETUP_PY" ]
 then
-    python $_PYPI_SETUP_PY sdist %s upload
+    python $_PYPI_SETUP_PY sdist %s upload -r %s
     if [ $? -ne 0 ]
     then
         echo "Deploy to PyPI failed - perhaps due to the version number not being incremented. Continuing..."
@@ -31,27 +32,41 @@ fi
 `
 
 type PyPI struct {
-	Username string   `yaml:"username,omitempty"`
-	Password string   `yaml:"password,omitempty"`
-	Formats  []string `yaml:"formats,omitempty"`
+	Username   string   `yaml:"username,omitempty"`
+	Password   string   `yaml:"password,omitempty"`
+	Formats    []string `yaml:"formats,omitempty"`
+	Repository string   `yaml:"repository,omitempty"`
 }
 
 func (p *PyPI) Write(f *buildfile.Buildfile) {
+	var indexServer string
+	var repository string
+
 	if len(p.Username) == 0 || len(p.Password) == 0 {
 		// nothing to do if the config is fundamentally flawed
 		return
 	}
+
+	// Handle the setting a custom pypi server/repository
+	if len(p.Repository) == 0 {
+		indexServer = "pypi"
+		repository = ""
+	} else {
+		indexServer = "custom"
+		repository = fmt.Sprintf("repository:%s", p.Repository)
+	}
+
 	f.WriteCmdSilent("echo 'publishing to PyPI...'")
 
 	// find the setup.py file
 	f.WriteCmdSilent("_PYPI_SETUP_PY=$(find . -name 'setup.py')")
 
 	// build the .pypirc file that pypi expects
-	f.WriteCmdSilent(fmt.Sprintf(pypirc, p.Username, p.Password))
+	f.WriteCmdSilent(fmt.Sprintf(pypirc, indexServer, indexServer, p.Username, p.Password, repository))
 	formatStr := p.BuildFormatStr()
 
 	// if we found the setup.py file use it to deploy
-	f.WriteCmdSilent(fmt.Sprintf(deployCmd, formatStr))
+	f.WriteCmdSilent(fmt.Sprintf(deployCmd, formatStr, indexServer))
 }
 
 func (p *PyPI) BuildFormatStr() string {


### PR DESCRIPTION
This pull request adds an additional `repository` option to the `pypi` publish plugin, to allow you to specify the URL to a custom PyPI compatible package index such as something like https://pypi.python.org/pypi/pypiserver

Sample usage looks like:

```
publish:
  pypi:
    username: {{pypi_user}}
    password: {{pypi_pass}}
    repository: http://pypi.example.org:8080
```

Additionally there appears to have been some reverse logic in the if statement in `deployCmd` where `-z` was used to validate the existence of a string.  I believe that `-n` was the intended test to use there, since `-z` tests if a string is empty and `-n` tests that it is not empty.  As such, the plugin does not work without this change.
