### PR TITLE
inject environment variables for drone-cli inspired by pull request #74

### DIFF
--- a/pkg/build/script/script.go
+++ b/pkg/build/script/script.go
@@ -23,13 +23,13 @@ func ParseBuild(data []byte, params map[string]string) (*Build, error) {
 	return &build, err
 }
 
-func ParseBuildFile(filename string) (*Build, error) {
+func ParseBuildFile(filename string, params map[string]string) (*Build, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	return ParseBuild(data, nil)
+	return ParseBuild(data, params)
 }
 
 // injectParams injects params into data.


### PR DESCRIPTION
In pull request #68, @bradrydzewski mentioned that it would be great if it can inject _local environment variables_ into the `.drone.yml` when running drone cli from client. for example:

```
AWS_KEY=xxxx AWS_SECRET=yyyy drone build
```

This change works in the same way as the feature injected parameters.
