### PR TITLE
Log errors inspecting images.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -244,6 +244,8 @@ func (b *Builder) setup() error {
 		if err := b.dockerClient.Images.Pull(b.Build.Image); err != nil {
 			return err
 		}
+	} else if err != nil {
+		log.Errf("failed to inspect image %s", b.Build.Image)
 	}
 
 	// create the Docker image


### PR DESCRIPTION
I've been noticing occasional cases where an image inspection seems to fail. I'm not sure what _should_ happen, but I figured a good first step would be to log the error.
