### PR TITLE
specify session secret on startup

### DIFF
--- a/cmd/droned/drone.go
+++ b/cmd/droned/drone.go
@@ -44,6 +44,11 @@ var (
 	// Number of concurrent build workers to run
 	// default to number of CPUs on machine
 	workers int
+
+	// Secret key to use when signing session cookies. If
+	// none specified, generate a unique one on every
+	// start
+	secret string
 )
 
 func main() {
@@ -55,6 +60,7 @@ func main() {
 	flag.StringVar(&sslkey, "sslkey", "", "")
 	flag.DurationVar(&timeout, "timeout", 300*time.Minute, "")
 	flag.IntVar(&workers, "workers", runtime.NumCPU(), "")
+	flag.StringVar(&secret, "secret", "", "")
 	flag.Parse()
 
 	// validate the TLS arguments
@@ -66,6 +72,7 @@ func main() {
 	}
 	discardOldBuilds()
 	setupStatic()
+	setupSecret()
 	setupHandlers()
 
 	// debug
@@ -125,6 +132,17 @@ func setupStatic() {
 		// serce images
 		images.ServeHTTP(w, r)
 	})
+}
+
+// sets the secret, if it exists
+func setupSecret() {
+	if secret != "" {
+		if len(secret) < 30 {
+			log.Fatal("Secret keys less than 30 characters are insecure!")
+		}
+
+		handler.SetSecret(secret)
+	}
 }
 
 // setup routes for serving dynamic content.

--- a/deb/drone/etc/default/drone
+++ b/deb/drone/etc/default/drone
@@ -7,5 +7,6 @@
 #   -path="":
 #   -port=":8080":
 #   -workers="4":
+#   -secret="c27e8eb83be1f23dd55977198bdc32e63dd581b99df97497af"
 #         
 #DRONED_OPTS="--port=:80"

--- a/pkg/handler/app.go
+++ b/pkg/handler/app.go
@@ -29,6 +29,10 @@ func generateRandomKey(strength int) []byte {
 	return k
 }
 
+func SetSecret(sec string) {
+	secret = []byte(sec)
+}
+
 // Returns an HTML index.html page if the user is
 // not currently authenticated, otherwise redirects
 // the user to their personal dashboard screen


### PR DESCRIPTION
This will allow sessions to persist across drone restarts.

Since the secret is used for session signing, I required the secret to be at least 30 characters, but it's somewhat arbitrary.
