### PR TITLE
Update buildscript for old builds

### DIFF
--- a/pkg/database/migrate/20140522205400_save_drone_yml.go
+++ b/pkg/database/migrate/20140522205400_save_drone_yml.go
@@ -10,6 +10,7 @@ func (r *rev20140522205400) Revision() int64 {
 
 func (r *rev20140522205400) Up(mg *MigrationDriver) error {
 	_, err := mg.AddColumn("builds", "buildscript TEXT")
+	_, err = mg.Tx.Exec("UPDATE builds SET buildscript = '' WHERE buildscript IS NULL")
 	return err
 }
 


### PR DESCRIPTION
Following error occurs after upgrade to awesome feature #318 :

```
sql: Scan error on column index 10: unsupported driver -> Scan pair: <nil> -> *string
```

Error is caused because old builds have `null` value in column `buildscript` in table `builds`.
