### PR TITLE
Typo in Comments: serce => serve

### DIFF
--- a/cmd/droned/drone.go
+++ b/cmd/droned/drone.go
@@ -122,7 +122,7 @@ func setupStatic() {
 			w.Header().Add("Cache-Control", "no-cache")
 		}
 
-		// serce images
+		// serve images
 		images.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Very simple typo I found in the comments for the droned source.
