### PR TITLE
Add option to manipulate the repo url

### DIFF
--- a/pkg/handler/repos.go
+++ b/pkg/handler/repos.go
@@ -326,6 +326,7 @@ func RepoUpdate(w http.ResponseWriter, r *http.Request, u *User, repo *Repo) err
 			return err
 		}
 	default:
+		repo.URL = r.FormValue("URL")
 		repo.Disabled = len(r.FormValue("Disabled")) == 0
 		repo.DisabledPullRequest = len(r.FormValue("DisabledPullRequest")) == 0
 		repo.Private = len(r.FormValue("Private")) > 0

--- a/pkg/template/pages/repo_settings.html
+++ b/pkg/template/pages/repo_settings.html
@@ -31,6 +31,10 @@
 		<div class="col-xs-9" role="main">
 			<div class="alert">Manage your repository settings.</div>
 				<form method="POST" action="/{{.Repo.Slug}}" role="form">
+					<div class="form-group">
+						<label>Repository URL</label>
+						<input class="form-control form-control-xlarge" type="text" name="URL" value="{{.Repo.URL}}" />
+					</div>
 					<div class="checkbox form-group">
 						<label>
 							<input class="" type="checkbox" name="Disabled" {{ if not .Repo.Disabled }}checked="True" {{ end }}/>


### PR DESCRIPTION
Until we get #91 taken care of, the only way to switch to another protocol for a git repo is to manipulate the sqlite database.  While I love making changes directly to the database, it's probably best that we add a input field for this configuration.

This pull request simply adds a new input field and handles the post data for the URL option.
