### PR TITLE
Add git path overrides

### DIFF
--- a/pkg/build/git/git.go
+++ b/pkg/build/git/git.go
@@ -13,10 +13,7 @@ type Git struct {
 	Depth *int `yaml:"depth,omitempty"`
 
 	// The name of a directory to clone into.
-	// TODO this still needs to be implemented. this field is
-	//      critical for forked Go projects, that need to clone
-	//      to a specific repository.
-	Path string `yaml:"path,omitempty"`
+	Path *string `yaml:"path,omitempty"`
 }
 
 // GitDepth returns GitDefaultDepth
@@ -28,4 +25,15 @@ func GitDepth(g *Git) int {
 		return DefaultGitDepth
 	}
 	return *g.Depth
+}
+
+// GitPath returns the given default path
+// when Git.Path is empty.
+// GitPath returns Git.Path
+// when it is not empty.
+func GitPath(g *Git, defaultPath string) string {
+	if g == nil || g.Path == nil {
+		return defaultPath
+	}
+	return *g.Path
 }

--- a/pkg/queue/worker.go
+++ b/pkg/queue/worker.go
@@ -184,7 +184,7 @@ func (w *worker) runBuild(task *BuildTask, buildscript *script.Build, buf io.Wri
 		Branch: task.Commit.Branch,
 		Commit: task.Commit.Hash,
 		PR:     task.Commit.PullRequest,
-		Dir:    filepath.Join("/var/cache/drone/src", task.Repo.Slug),
+		Dir:    filepath.Join("/var/cache/drone/src", git.GitPath(buildscript.Git, task.Repo.Slug)),
 		Depth:  git.GitDepth(buildscript.Git),
 	}
 


### PR DESCRIPTION
This commit lets build scripts define a custom path to clone the repository into. This allows drone to support Go projects that have an import path that differs from the clone url.
