### PR TITLE
UX: Make repo name clickable to go back to the commit history

### DIFF
--- a/pkg/template/pages/repo_settings.html
+++ b/pkg/template/pages/repo_settings.html
@@ -8,8 +8,8 @@
 				<li class="active"><a href="/{{.Repo.Slug}}/settings">Settings</a></li>
 			</ul> <!-- ./nav -->
 			<h1>
-				<span>{{.Repo.Name}}</span>
-				<small>{{.Repo.Owner}}</small>
+				<span><a href="/{{.Repo.Slug}}">{{.Repo.Name}}</a></span>
+				<small><a href="/{{.Repo.Slug}}">{{.Repo.Owner}}</a></small>
 			</h1>
 		</div><!-- ./container -->
 	</div><!-- ./subhead -->


### PR DESCRIPTION
Very small fix but I have been annoyed by this for a while ;)
