### PR TITLE
Fix force option of git/heroku/tsuru deploy plugin

### DIFF
--- a/pkg/plugin/deploy/git.go
+++ b/pkg/plugin/deploy/git.go
@@ -35,7 +35,7 @@ func (g *Git) Write(f *buildfile.Buildfile) {
 		// that need to be deployed to git remote.
 		f.WriteCmd(fmt.Sprintf("git add -A"))
 		f.WriteCmd(fmt.Sprintf("git commit -m 'add build artifacts'"))
-		f.WriteCmd(fmt.Sprintf("git push deploy $COMMIT:%s --force", destinationBranch))
+		f.WriteCmd(fmt.Sprintf("git push deploy HEAD:%s --force", destinationBranch))
 	case false:
 		// otherwise we just do a standard git push
 		f.WriteCmd(fmt.Sprintf("git push deploy $COMMIT:%s", destinationBranch))

--- a/pkg/plugin/deploy/heroku.go
+++ b/pkg/plugin/deploy/heroku.go
@@ -30,7 +30,7 @@ func (h *Heroku) Write(f *buildfile.Buildfile) {
 		// that need to be deployed to Heroku.
 		f.WriteCmd(fmt.Sprintf("git add -A"))
 		f.WriteCmd(fmt.Sprintf("git commit -m 'adding build artifacts'"))
-		f.WriteCmd(fmt.Sprintf("git push heroku $COMMIT:master --force"))
+		f.WriteCmd(fmt.Sprintf("git push heroku HEAD:master --force"))
 	case false:
 		// otherwise we just do a standard git push
 		f.WriteCmd(fmt.Sprintf("git push heroku $COMMIT:master"))

--- a/pkg/plugin/deploy/tsuru.go
+++ b/pkg/plugin/deploy/tsuru.go
@@ -30,7 +30,7 @@ func (h *Tsuru) Write(f *buildfile.Buildfile) {
 		// that need to be deployed to Tsuru.
 		f.WriteCmd(fmt.Sprintf("git add -A"))
 		f.WriteCmd(fmt.Sprintf("git commit -m 'adding build artifacts'"))
-		f.WriteCmd(fmt.Sprintf("git push tsuru $COMMIT:master --force"))
+		f.WriteCmd(fmt.Sprintf("git push tsuru HEAD:master --force"))
 	case false:
 		// otherwise we just do a standard git push
 		f.WriteCmd(fmt.Sprintf("git push tsuru $COMMIT:master"))


### PR DESCRIPTION
The build artifacts were actually not pushed because the HEAD ref before
the commit 'add build artifacts' was used in the git push command.
