### PR TITLE
Dropped seemingly-unsupported `path` flag suggestion

### DIFF
--- a/deb/drone/etc/default/drone
+++ b/deb/drone/etc/default/drone
@@ -4,7 +4,6 @@
 #
 #   -datasource="drone.sqlite":
 #   -driver="sqlite3":
-#   -path="":
 #   -port=":8080":
 #   -workers="4":
 #         


### PR DESCRIPTION
Tiny, cosmetic, but from latest packaged drone:

```
$ droned --path wibble
flag provided but not defined: -path
<snip>
```

(I'm currently writing a Puppet module, so exploring config options)
