### PR TITLE
Status.json page

### DIFF
--- a/cmd/droned/drone.go
+++ b/cmd/droned/drone.go
@@ -227,6 +227,7 @@ func setupHandlers() {
 
 	// handlers for repository, commits and build details
 	m.Get("/:host/:owner/:name/commit/:commit/build/:label/out.txt", handler.RepoHandler(handler.BuildOut))
+	m.Get("/:host/:owner/:name/commit/:commit/build/:label/status.json", handler.PublicHandler(handler.BuildStatus))
 	m.Post("/:host/:owner/:name/commit/:commit/build/:label/rebuild", handler.RepoAdminHandler(rebuild.CommitRebuild))
 	m.Get("/:host/:owner/:name/commit/:commit/build/:label", handler.RepoHandler(handler.CommitShow))
 	m.Post("/:host/:owner/:name/commit/:commit/rebuild", handler.RepoAdminHandler(rebuild.CommitRebuild))

--- a/pkg/handler/builds.go
+++ b/pkg/handler/builds.go
@@ -7,6 +7,10 @@ import (
 	. "github.com/drone/drone/pkg/model"
 )
 
+type BuildResult struct {
+	Status string
+}
+
 // Returns the combined stdout / stderr for an individual Build.
 func BuildOut(w http.ResponseWriter, r *http.Request, u *User, repo *Repo) error {
 	branch := r.FormValue("branch")
@@ -30,6 +34,33 @@ func BuildOut(w http.ResponseWriter, r *http.Request, u *User, repo *Repo) error
 	}
 
 	return RenderText(w, build.Stdout, http.StatusOK)
+}
+
+// Returns the combined stdout / stderr for an individual Build.
+func BuildStatus(w http.ResponseWriter, r *http.Request, repo *Repo) error {
+	branch := r.FormValue("branch")
+	if branch == "" {
+		branch = "master"
+	}
+
+	hash := r.FormValue(":commit")
+	labl := r.FormValue(":label")
+
+	// get the commit from the database
+	commit, err := database.GetCommitBranchHash(branch, hash, repo.ID)
+	if err != nil {
+		return err
+	}
+
+	// get the build from the database
+	build, err := database.GetBuildSlug(labl, commit.ID)
+	if err != nil {
+		return err
+	}
+
+	build_result := BuildResult{build.Status}
+
+	return RenderJson(w, build_result)
 }
 
 // Returns the gzipped stdout / stderr for an individual Build


### PR DESCRIPTION
A simple public page, for external services to show current build status

`/:host/:owner/:name/commit/:commit/build/:label/status.json`

``` json
{
  "Status": "Success"
}
```

``` json
{
  "Status":"Failure"
}
```
