### PR TITLE
Use godep in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,15 @@ RUN wget https://go.googlecode.com/files/go1.2.src.tar.gz && tar zxvf go1.2.src.
 ENV PATH $PATH:/go/bin:/gocode/bin
 ENV GOPATH /gocode
 
+RUN go get github.com/tools/godep
+
 RUN mkdir -p /gocode/src/github.com/drone
 
 ADD . /gocode/src/github.com/drone/drone
 
 WORKDIR /gocode/src/github.com/drone/drone
 
-RUN make deps
+RUN godep restore
 RUN make
 RUN make install
 


### PR DESCRIPTION
Add `godep` to `Dockerfile` to install dependencies.

The current `Dockerfile` uses `make deps`, but the `go get` used internally no longer works because `github.com/dotcloud` moved to `github.com/docker`.
