### PR TITLE
Fix dependency of ParseRepositoryTag

### DIFF
--- a/pkg/build/docker/image.go
+++ b/pkg/build/docker/image.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/dotcloud/docker/archive"
-	"github.com/dotcloud/docker/utils"
+	"github.com/dotcloud/docker/pkg/parsers"
 )
 
 type Images struct {
@@ -63,7 +63,7 @@ func (c *ImageService) Create(image string) error {
 }
 
 func (c *ImageService) Pull(image string) error {
-	name, tag := utils.ParseRepositoryTag(image)
+	name, tag := parsers.ParseRepositoryTag(image)
 	if len(tag) == 0 {
 		tag = DEFAULTTAG
 	}


### PR DESCRIPTION
cause updating of dotcloud/docker, ParseRepositoryTag was moved.
So `RUN make` fails.

My environment is ubuntu 14.0.4.

```
root@a6db11b76295:/gocode/src/github.com/drone/drone# go build -o bin/drone github.com/drone/drone/cmd/drone
# github.com/drone/drone/pkg/build/docker
pkg/build/docker/image.go:66: undefined: "github.com/dotcloud/docker/utils".ParseRepositoryTag
```
