### PR TITLE
Make npm publish work without user credentials

### DIFF
--- a/pkg/plugin/publish/npm.go
+++ b/pkg/plugin/publish/npm.go
@@ -45,10 +45,6 @@ type NPM struct {
 
 func (n *NPM) Write(f *buildfile.Buildfile) {
 
-    if len(n.Email) == 0 || len(n.Username) == 0 || len(n.Password) == 0 {
-        return
-    }
-
     npmPublishCmd := "npm publish %s"
 
     if n.Tag != "" {
@@ -62,7 +58,9 @@ func (n *NPM) Write(f *buildfile.Buildfile) {
     f.WriteCmdSilent("echo 'publishing to NPM ...'")
 
     // Login to registry
-    f.WriteCmdSilent(fmt.Sprintf(npmLoginCmd, n.Username, n.Password, n.Email))
+    if len(n.Email) != 0 && len(n.Username) != 0 && len(n.Password) != 0 {
+		f.WriteCmdSilent(fmt.Sprintf(npmLoginCmd, n.Username, n.Password, n.Email))
+    }
 
     // Setup custom npm registry
     if n.Registry != "" {


### PR DESCRIPTION
In our environment we use custom docker images with npmrc using our own private registry. We need it, because access to private packages is restricted to authenticated users.

I have patched npm publish plugin to work without user credentials. Please consider adding this change to upstream release.
