### PR TITLE
Use SplitN instead of Split on = signs in script.go

### DIFF
--- a/pkg/build/script/script.go
+++ b/pkg/build/script/script.go
@@ -106,7 +106,7 @@ func (b *Build) Write(f *buildfile.Buildfile, r *repo.Repo) {
 func (b *Build) WriteBuild(f *buildfile.Buildfile) {
 	// append environment variables
 	for _, env := range b.Env {
-		parts := strings.Split(env, "=")
+		parts := strings.SplitN(env, "=", 2)
 		if len(parts) != 2 {
 			continue
 		}


### PR DESCRIPTION
= signs beyond the first should be considered part of the environment
variable.
