### PR TITLE
Fix #284: Do not checkout the branch if a commit or PR is specified.

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -568,7 +568,7 @@ func TestWriteBuildScript(t *testing.T) {
 	f.WriteEnv("CI_BRANCH", "master")
 	f.WriteEnv("CI_PULL_REQUEST", "123")
 	f.WriteHost("127.0.0.1")
-	f.WriteCmd("git clone --depth=0 --recursive --branch=master git://github.com/drone/drone.git /var/cache/drone/github.com/drone/drone")
+	f.WriteCmd("git clone --depth=0 --recursive git://github.com/drone/drone.git /var/cache/drone/github.com/drone/drone")
 	f.WriteCmd("git fetch origin +refs/pull/123/head:refs/remotes/origin/pr/123")
 	f.WriteCmd("git checkout -qf -b pr/123 origin/pr/123")
 

--- a/pkg/build/repo/repo.go
+++ b/pkg/build/repo/repo.go
@@ -103,21 +103,18 @@ func (r *Repo) Commands() []string {
 	}
 
 	cmds := []string{}
-	cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive --branch=%s %s %s", r.Depth, branch, r.Path, r.Dir))
-
-	switch {
-	// if a specific commit is provided then we'll
-	// need to clone it.
-	case len(r.PR) > 0:
-
+	if len(r.PR) > 0 {
+		// If a specific PR is provided then we need to clone it.
+		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive %s %s", r.Depth, r.Path, r.Dir))
 		cmds = append(cmds, fmt.Sprintf("git fetch origin +refs/pull/%s/head:refs/remotes/origin/pr/%s", r.PR, r.PR))
 		cmds = append(cmds, fmt.Sprintf("git checkout -qf -b pr/%s origin/pr/%s", r.PR, r.PR))
-		//cmds = append(cmds, fmt.Sprintf("git fetch origin +refs/pull/%s/merge:", r.PR))
-		//cmds = append(cmds, fmt.Sprintf("git checkout -qf %s", "FETCH_HEAD"))
-	// if a specific commit is provided then we'll
-	// need to clone it.
-	case len(r.Commit) > 0:
-		cmds = append(cmds, fmt.Sprintf("git checkout -qf %s", r.Commit))
+	} else {
+		// Otherwise just clone the branch.
+		cmds = append(cmds, fmt.Sprintf("git clone --depth=%d --recursive --branch=%s %s %s", r.Depth, branch, r.Path, r.Dir))
+		// If a specific commit is provided then we'll need to check it out.
+		if len(r.Commit) > 0 {
+			cmds = append(cmds, fmt.Sprintf("git checkout -qf %s", r.Commit))
+		}
 	}
 
 	return cmds


### PR DESCRIPTION
Because of #284, images containing more recent versions of git cannot be used.
