### PR TITLE
Adding apt-get update prior to attempting install of apt-transport-https...

### DIFF
--- a/pkg/plugin/publish/docker.go
+++ b/pkg/plugin/publish/docker.go
@@ -54,6 +54,8 @@ func (d *Docker) Write(f *buildfile.Buildfile, r *repo.Repo) {
 		return
 	}
 
+	f.WriteCmd("sudo apt-get update")
+
 	// Ensure correct apt-get has the https method-driver as per (http://askubuntu.com/questions/165676/)
 	f.WriteCmd("sudo apt-get install apt-transport-https")
 


### PR DESCRIPTION
... in docker publish plugin

to resolve #479 
