### PR TITLE
Fix some missing double-quotes around error messages in docker publish plugin

### DIFF
--- a/pkg/plugin/publish/docker.go
+++ b/pkg/plugin/publish/docker.go
@@ -46,11 +46,11 @@ type Docker struct {
 func (d *Docker) Write(f *buildfile.Buildfile, r *repo.Repo) {
 	if len(d.DockerServer) == 0 || d.DockerServerPort == 0 || len(d.DockerVersion) == 0 ||
 		len(d.ImageName) == 0 {
-		f.WriteCmdSilent(`echo -e "Docker Plugin: Missing argument(s)"\n\n`)
-		if len(d.DockerServer) == 0  { f.WriteCmdSilent(`echo -e "\tdocker_server not defined in yaml`) }
-		if d.DockerServerPort == 0   { f.WriteCmdSilent(`echo -e "\tdocker_port not defined in yaml`) }
-		if len(d.DockerVersion) == 0 { f.WriteCmdSilent(`echo -e "\tdocker_version not defined in yaml`) }
-		if len(d.ImageName) == 0     { f.WriteCmdSilent(`echo -e "\timage_name not defined in yaml`) }
+		f.WriteCmdSilent(`echo -e "Docker Plugin: Missing argument(s)\n\n"`)
+		if len(d.DockerServer) == 0  { f.WriteCmdSilent(`echo -e "\tdocker_server not defined in yaml"`) }
+		if d.DockerServerPort == 0   { f.WriteCmdSilent(`echo -e "\tdocker_port not defined in yaml"`) }
+		if len(d.DockerVersion) == 0 { f.WriteCmdSilent(`echo -e "\tdocker_version not defined in yaml"`) }
+		if len(d.ImageName) == 0     { f.WriteCmdSilent(`echo -e "\timage_name not defined in yaml"`) }
 		return
 	}
 


### PR DESCRIPTION
Hi,

Was testing this out and running into the following error when attempting to use the publish to docker feature:

```
Docker Plugin: Missing argument(s)nn
/usr/local/bin/drone: line 40: unexpected EOF while looking for matching `"'
```

After a bit of sleuthing I found that it is trying to echo helpful error messages that are missing a closing double-quote, so users like myself don't get an informative message.

Furthermore, it turns out that the configuration paramswrongly documented. It should be 'docker_server' instead of 'docker_host' in .drone.yml
