### PR TITLE
Escape under \x40 control chars in branch name

### DIFF
--- a/pkg/handler/commits.go
+++ b/pkg/handler/commits.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/drone/drone/pkg/channel"
@@ -26,6 +27,7 @@ func CommitShow(w http.ResponseWriter, r *http.Request, u *User, repo *Repo) err
 	if err != nil {
 		return err
 	}
+	branch = url.QueryEscape(commit.Branch)
 
 	// get the builds from the database. a commit can have
 	// multiple sub-builds (or matrix builds)
@@ -45,9 +47,10 @@ func CommitShow(w http.ResponseWriter, r *http.Request, u *User, repo *Repo) err
 		Commit  *Commit
 		Build   *Build
 		Builds  []*Build
+		Branch  string
 		Token   string
 		IsAdmin bool
-	}{u, repo, commit, builds[0], builds, "", admin}
+	}{u, repo, commit, builds[0], builds, branch, "", admin}
 
 	// get the specific build requested by the user. instead
 	// of a database round trip, we can just loop through the
@@ -161,9 +164,9 @@ func (h *CommitRebuildHandler) CommitRebuild(w http.ResponseWriter, r *http.Requ
 	h.queue.Add(&queue.BuildTask{Repo: repo, Commit: commit, Build: build})
 
 	if labl != "" {
-		http.Redirect(w, r, fmt.Sprintf("/%s/%s/%s/commit/%s/build/%s?branch=%s", host, repo.Owner, repo.Name, hash, labl, branch), http.StatusSeeOther)
+		http.Redirect(w, r, fmt.Sprintf("/%s/%s/%s/commit/%s/build/%s?branch=%s", host, repo.Owner, repo.Name, hash, labl, url.QueryEscape(branch)), http.StatusSeeOther)
 	} else {
-		http.Redirect(w, r, fmt.Sprintf("/%s/%s/%s/commit/%s?branch=%s", host, repo.Owner, repo.Name, hash, branch), http.StatusSeeOther)
+		http.Redirect(w, r, fmt.Sprintf("/%s/%s/%s/commit/%s?branch=%s", host, repo.Owner, repo.Name, hash, url.QueryEscape(branch)), http.StatusSeeOther)
 	}
 
 	return nil

--- a/pkg/template/pages/repo_commit.html
+++ b/pkg/template/pages/repo_commit.html
@@ -5,7 +5,7 @@
 	<div class="subhead">
 		<div class="container">
 			<ul class="nav nav-tabs pull-right">
-				<li class="active"><a href="/{{.Repo.Slug}}/commit/{{ .Commit.Hash }}?branch={{ .Commit.Branch }}">{{ .Commit.HashShort }}</a></li>
+				<li class="active"><a href="/{{.Repo.Slug}}/commit/{{ .Commit.Hash }}?branch={{ .Branch }}">{{ .Commit.HashShort }}</a></li>
 				<li><a href="/{{.Repo.Slug}}">Commits</a></li>
 				<li><a href="/{{.Repo.Slug}}/settings">Settings</a></li>
 			</ul> <!-- ./nav -->
@@ -18,7 +18,7 @@
 
 	<div class="container">
 		<div class="alert alert-build-{{ .Build.Status }}">
-			<a href="/{{.Repo.Slug}}/commit/{{ .Commit.Hash }}?branch={{ .Commit.Branch }}" class="btn btn-{{ .Build.Status }}"></a>
+			<a href="/{{.Repo.Slug}}/commit/{{ .Commit.Hash }}?branch={{ .Branch }}" class="btn btn-{{ .Build.Status }}"></a>
 			{{ if .Commit.PullRequest }}
 			<span>opened pull request <span># {{ .Commit.PullRequest }}</span></span>
 			{{ else }}
@@ -90,7 +90,7 @@
 		});
 
 	{{ else }}
-		$.get("/{{ .Repo.Slug }}/commit/{{ .Commit.Hash }}/build/{{ .Build.Slug }}/out.txt?branch={{ .Commit.Branch }}", function( data ) {
+		$.get("/{{ .Repo.Slug }}/commit/{{ .Commit.Hash }}/build/{{ .Build.Slug }}/out.txt?branch={{ .Branch }}", function( data ) {
 			var lineFormatter = new Drone.LineFormatter();
 			$( "#stdout" ).html(lineFormatter.format(data));
 		});


### PR DESCRIPTION
## In this p-r, drone escape branch name in url context.

We want use under \x40 control chars in branch name but drone does not escape branch name in url context.

Of cause I know under \x40 chars are illegal in branch name. (`git check-ref-format --help`)
We use redmine as bts with github as code repository, so our branch names contain redmine's ticket id:
- `feature/some_fix_#12345`

Please merge this.
