### PR TITLE
Update Godeps.json

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -124,7 +124,7 @@
 			"Rev": "f68f5fd521270ad9775fb0adfe7516f9e4855ba5"
 		},
 		{
-			"ImportPath": "github.com/dotcloud/docker/archive",
+			"ImportPath": "github.com/dotcloud/docker/pkg/archive",
 			"Comment": "v1.2.0-576-gf68f5fd",
 			"Rev": "f68f5fd521270ad9775fb0adfe7516f9e4855ba5"
 		},


### PR DESCRIPTION
The `godep restore` command fails with the error 'cannot find package "github.com/dotcloud/docker/archive"'
