### PR TITLE
Fix camel case Commit property access in app.js

### DIFF
--- a/server/app/scripts/app.js
+++ b/server/app/scripts/app.js
@@ -231,10 +231,11 @@ app.controller("CommitController", function($scope, $http, $routeParams, stdout,
 	$scope.console='';
 
 	feed.subscribe(function(item) {
-		if (item.commit.sha    == commit &&
-			item.commit.branch == branch) {
-			$scope.commit = item.commit;
+		if (item.Commit.sha    == commit &&
+			item.Commit.branch == branch) {
+			$scope.commit = item.Commit;
 			$scope.$apply();
+
 		} else {
 			// we trigger an toast notification so the
 			// user is aware another build started


### PR DESCRIPTION
Sorry, realized how useless this is without more information:

Running rebuild goes through the attached section of code and uses `commit` instead of `Commit`, dooming the rebuild to fail silently. This seems to fix that but I haven't tested it in anything other than the web inspector.
