### PR TITLE
Fix make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ build:
 	go build -o packaging/root/usr/local/bin/droned -ldflags "-X main.revision $(SHA)" github.com/drone/drone/server
 
 install:
-	install -t /usr/local/bin debian/drone/usr/local/bin/drone 
-	install -t /usr/local/bin debian/drone/usr/local/bin/droned 
+	install -t /usr/local/bin packaging/root/usr/local/bin/drone 
+	install -t /usr/local/bin packaging/root/usr/local/bin/droned 
 
 run:
 	@go run server/main.go --config=$$HOME/.drone/config.toml


### PR DESCRIPTION
Fixes:

```
install: cannot stat `debian/drone/usr/local/bin/drone': No such file or directory
make: *** [install] Error 1
```
