### PR TITLE
Add docker section in .drone.yml with net option

### DIFF
--- a/shared/build/build.go
+++ b/shared/build/build.go
@@ -328,6 +328,11 @@ func (b *Builder) run() error {
 	// configure if Docker should run in privileged mode
 	host := docker.HostConfig{
 		Privileged: (b.Privileged && len(b.Repo.PR) == 0),
+		NetworkMode: docker.DefaultDockerNetworkMode,
+	}
+
+	if host.Privileged {
+		host.NetworkMode = docker.DockerNetworkMode(b.Build.Docker)
 	}
 
 	// debugging

--- a/shared/build/docker/docker.go
+++ b/shared/build/docker/docker.go
@@ -1,0 +1,24 @@
+package docker
+
+const (
+    DefaultDockerNetworkMode = "bridge"
+)
+
+// Docker stores the configuration details for
+// configuring docker container.
+type Docker struct {
+    // NetworkMode (also known as `--net` option)
+    // Could be set only if Docker is running in privileged mode
+    NetworkMode *string `yaml:"net,omitempty"`
+}
+
+// DockerNetworkMode returns DefaultNetworkMode
+// when Docker.NetworkMode is empty.
+// DockerNetworkMode returns Docker.NetworkMode
+// when it is not empty.
+func DockerNetworkMode(d *Docker) string {
+    if d == nil || d.NetworkMode == nil {
+        return DefaultDockerNetworkMode
+    }
+    return *d.NetworkMode
+}

--- a/shared/build/docker/docker_test.go
+++ b/shared/build/docker/docker_test.go
@@ -1,0 +1,40 @@
+package docker
+
+import (
+    "testing"
+)
+
+func TestDockerNetworkMode(t *testing.T) {
+    var d *Docker
+    var expected string
+
+    expected = DefaultDockerNetworkMode
+    d = nil
+    if actual := DockerNetworkMode(d); actual != expected {
+        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+    }
+
+    expected = DefaultDockerNetworkMode
+    d = &Docker{}
+    if actual := DockerNetworkMode(d); actual != expected {
+        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+    }
+
+    expected = DefaultDockerNetworkMode
+    d = &Docker{NetworkMode: nil}
+    if actual := DockerNetworkMode(d); actual != expected {
+        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+    }
+
+    expected = "bridge"
+    d = &Docker{NetworkMode: &expected}
+    if actual := DockerNetworkMode(d); actual != expected {
+        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+    }
+
+    expected = "host"
+    d = &Docker{NetworkMode: &expected}
+    if actual := DockerNetworkMode(d); actual != expected {
+        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+    }
+}

--- a/shared/build/docker/structs.go
+++ b/shared/build/docker/structs.go
@@ -19,6 +19,7 @@ type KeyValuePair struct {
 type HostConfig struct {
 	Binds           []string
 	ContainerIDFile string
+	NetworkMode     string
 	LxcConf         []KeyValuePair
 	Privileged      bool
 	PortBindings    map[Port][]PortBinding

--- a/shared/build/script/script.go
+++ b/shared/build/script/script.go
@@ -11,6 +11,7 @@ import (
 	"github.com/drone/drone/plugin/publish"
 	"github.com/drone/drone/shared/build/buildfile"
 	"github.com/drone/drone/shared/build/git"
+	"github.com/drone/drone/shared/build/docker"
 	"github.com/drone/drone/shared/build/repo"
 )
 
@@ -71,6 +72,10 @@ type Build struct {
 	// Git specified git-specific parameters, such as
 	// the clone depth and path
 	Git *git.Git `yaml:"git,omitempty"`
+
+	// Docker container parameters, such as
+	// NetworkMode and UserName
+	Docker *docker.Docker `yaml:"docker,omitempty"`
 }
 
 // Write adds all the steps to the build script, including


### PR DESCRIPTION
This PR introduces `docker` section in `.drone.yml` file and `net` option in this section.

`net` option should be used to configure [`--net` parameter](https://docs.docker.com/articles/networking/#container-networking) of Docker container.

Default value: `bridge`

Example:

``` yml
docker:
  net: host
```
