### PR TITLE
Detect https scheme when serving ssl

### DIFF
--- a/shared/httputil/httputil.go
+++ b/shared/httputil/httputil.go
@@ -13,6 +13,8 @@ func IsHttps(r *http.Request) bool {
 	switch {
 	case r.URL.Scheme == "https":
 		return true
+	case r.TLS != nil:
+		return true
 	case strings.HasPrefix(r.Proto, "HTTPS"):
 		return true
 	case r.Header.Get("X-Forwarded-Proto") == "https":
@@ -29,6 +31,8 @@ func IsHttps(r *http.Request) bool {
 func GetScheme(r *http.Request) string {
 	switch {
 	case r.URL.Scheme == "https":
+		return "https"
+	case r.TLS != nil:
 		return "https"
 	case strings.HasPrefix(r.Proto, "HTTPS"):
 		return "https"


### PR DESCRIPTION
Running droned with --sslcert enables SSL, but drone enters a redirection loop authenticating a user using Github OAuth endpoints because  `redirect_uri` query parameter generated by `/api/auth/github.com` endpoint "http://" instead of "https://". It doesn't match the redirect_uri set on Github settings for the app, so it fails.  
