### PR TITLE
Add worker-net parameter in configs

### DIFF
--- a/packaging/root/etc/drone/drone.toml
+++ b/packaging/root/etc/drone/drone.toml
@@ -29,7 +29,7 @@ datasource="/var/lib/drone/drone.sqlite"
 # firewall.
 #
 # When false, the system admin will need to manually add
-# users to Drone through the admin screens. 
+# users to Drone through the admin screens.
 #
 # [registration]
 # open=true
@@ -69,3 +69,4 @@ datasource="/var/lib/drone/drone.sqlite"
 #   "unix:///var/run/docker.sock",
 #   "unix:///var/run/docker.sock"
 # ]
+# net="bridge"

--- a/shared/build/build.go
+++ b/shared/build/build.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/drone/config"
 	"github.com/drone/drone/shared/build/buildfile"
 	"github.com/drone/drone/shared/build/docker"
 	"github.com/drone/drone/shared/build/dockerfile"
@@ -17,6 +18,10 @@ import (
 	"github.com/drone/drone/shared/build/proxy"
 	"github.com/drone/drone/shared/build/repo"
 	"github.com/drone/drone/shared/build/script"
+)
+
+var (
+	networkmode = config.String("worker-net", "")
 )
 
 // BuildState stores information about a build
@@ -328,6 +333,7 @@ func (b *Builder) run() error {
 	// configure if Docker should run in privileged mode
 	host := docker.HostConfig{
 		Privileged: (b.Privileged && len(b.Repo.PR) == 0),
+		NetworkMode: *networkmode,
 	}
 
 	// debugging

--- a/shared/build/docker/structs.go
+++ b/shared/build/docker/structs.go
@@ -19,6 +19,7 @@ type KeyValuePair struct {
 type HostConfig struct {
 	Binds           []string
 	ContainerIDFile string
+	NetworkMode     string
 	LxcConf         []KeyValuePair
 	Privileged      bool
 	PortBindings    map[Port][]PortBinding


### PR DESCRIPTION
This would give a way to change `NetworkMode` in case of IPv6-only hosts to `host` mode (cont. of https://github.com/drone/drone/pull/573).
