### PR TITLE
Use well known DOCKER_HOST syntax for Docker publish

### DIFF
--- a/plugin/publish/docker.go
+++ b/plugin/publish/docker.go
@@ -2,7 +2,6 @@ package publish
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/drone/drone/plugin/condition"
 	"github.com/drone/drone/shared/build/buildfile"
@@ -14,8 +13,8 @@ type Docker struct {
 	Dockerfile string `yaml:"docker_file"`
 
 	// Connection information for the docker server that will build the image
-	DockerServer     string `yaml:"docker_server"`
-	DockerServerPort int    `yaml:"docker_port"`
+	// Same format than DOCKER_HOST envvar, i.e.: tcp://172.16.1.1:2375
+	DockerHost string `yaml:"docker_host"`
 	// The Docker client version to download. This must match the docker version on the server
 	DockerVersion string `yaml:"docker_version"`
 
@@ -45,14 +44,10 @@ type Docker struct {
 // 3. Push that docker image to index.docker.io.
 // 4. Delete the docker image on the server it was build on so we conserve disk space.
 func (d *Docker) Write(f *buildfile.Buildfile) {
-	if len(d.DockerServer) == 0 || d.DockerServerPort == 0 || len(d.DockerVersion) == 0 ||
-		len(d.ImageName) == 0 {
+	if len(d.DockerHost) == 0 || len(d.DockerVersion) == 0 || len(d.ImageName) == 0 {
 		f.WriteCmdSilent(`echo -e "Docker Plugin: Missing argument(s)\n\n"`)
-		if len(d.DockerServer) == 0 {
-			f.WriteCmdSilent(`echo -e "\tdocker_server not defined in yaml"`)
-		}
-		if d.DockerServerPort == 0 {
-			f.WriteCmdSilent(`echo -e "\tdocker_port not defined in yaml"`)
+		if len(d.DockerHost) == 0 {
+			f.WriteCmdSilent(`echo -e "\tdocker_host not defined in yaml"`)
 		}
 		if len(d.DockerVersion) == 0 {
 			f.WriteCmdSilent(`echo -e "\tdocker_version not defined in yaml"`)
@@ -65,9 +60,6 @@ func (d *Docker) Write(f *buildfile.Buildfile) {
 	// Download docker binary and install it as /usr/local/bin/docker
 	f.WriteCmd("wget -qO- https://get.docker.io/builds/Linux/x86_64/docker-" +
 		d.DockerVersion + ".tgz |sudo tar zxf - -C /")
-
-	// Format our Build Server Endpoint
-	dockerServerUrl := d.DockerServer + ":" + strconv.Itoa(d.DockerServerPort)
 
 	dockerPath := "."
 	if len(d.Dockerfile) != 0 {
@@ -82,36 +74,29 @@ func (d *Docker) Write(f *buildfile.Buildfile) {
 	} else {
 		imageTag = "$(git rev-parse --short HEAD)"
 	}
-	f.WriteCmd(fmt.Sprintf("docker -H %s build -t %s:%s %s", dockerServerUrl, d.ImageName, imageTag, dockerPath))
+	f.WriteCmd("export DOCKER_HOST=" + d.DockerHost)
+	f.WriteCmd(fmt.Sprintf("docker build -t %s:%s %s", d.ImageName, imageTag, dockerPath))
 
 	// Login?
 	if d.RegistryLogin == true {
-		// Are we logging in to a custom Registry?
-		if len(d.RegistryLoginUrl) > 0 {
-			f.WriteCmdSilent(fmt.Sprintf("docker -H %s login -u %s -p %s -e %s %s",
-				dockerServerUrl, d.Username, d.Password, d.Email, d.RegistryLoginUrl))
-		} else {
-			// Assume index.docker.io
-			f.WriteCmdSilent(fmt.Sprintf("docker -H %s login -u %s -p %s -e %s",
-				dockerServerUrl, d.Username, d.Password, d.Email))
-		}
+		f.WriteCmdSilent(fmt.Sprintf("docker login -u %s -p %s -e %s %s",
+			d.Username, d.Password, d.Email, d.RegistryLoginUrl))
 	}
+	// Push the tagged image only - Do not push all image tags
+	f.WriteCmd(fmt.Sprintf("docker push %s:%s", d.ImageName, imageTag))
 
 	// Are we overriding the "latest" tag?
 	if d.PushLatest {
-		f.WriteCmd(fmt.Sprintf("docker -H %s tag %s:%s %s:latest",
-			dockerServerUrl, d.ImageName, imageTag, d.ImageName))
+		f.WriteCmd(fmt.Sprintf("docker tag %s:%s %s:latest",
+			d.ImageName, imageTag, d.ImageName))
+		f.WriteCmd(fmt.Sprintf("docker push %s:latest", d.ImageName))
 	}
-
-	f.WriteCmd(fmt.Sprintf("docker -H %s push %s", dockerServerUrl, d.ImageName))
 
 	// Delete the image from the docker server we built on.
 	if !d.KeepBuild {
-		f.WriteCmd(fmt.Sprintf("docker -H %s rmi %s:%s",
-			dockerServerUrl, d.ImageName, imageTag))
+		f.WriteCmd(fmt.Sprintf("docker rmi %s:%s", d.ImageName, imageTag))
 		if d.PushLatest {
-			f.WriteCmd(fmt.Sprintf("docker -H %s rmi %s:latest",
-				dockerServerUrl, d.ImageName))
+			f.WriteCmd(fmt.Sprintf("docker rmi %s:latest", d.ImageName))
 		}
 	}
 }


### PR DESCRIPTION
The main idea behind this PR is to replace `docker_server` and `docker_port` by `docker_host` directive, it follows the environment variable DOCKER_HOST format recognized by docker clients. Also export DOCKER_HOST instead of appending `-H` option to every docker call.

~~I included another bonus change, "docker push" is done per known tag to avoid pushing all existent tags everytime in case keep_build is true.~~ (#593 is better scoped for this change).  

Any feedback is welcome.
