### PR TITLE
Fix RawAuthor -> Author

### DIFF
--- a/plugin/remote/bitbucket/bitbucket.go
+++ b/plugin/remote/bitbucket/bitbucket.go
@@ -251,7 +251,7 @@ func (r *Bitbucket) ParseHook(req *http.Request) (*model.Hook, error) {
 		return nil, fmt.Errorf("Invalid Bitbucket post-commit Hook. Missing Repo or Commit data.")
 	}
 
-	var author = hook.Commits[len(hook.Commits)-1].RawAuthor
+	var author = hook.Commits[len(hook.Commits)-1].Author
 	var matches = emailRegexp.FindStringSubmatch(author)
 	if len(matches) == 2 {
 		author = matches[1]


### PR DESCRIPTION
I got strange error, when run `make deps` in fresh master branch:

```
floatdrop@drone:~/go/src/github.com/drone/drone$ make
mkdir -p packaging/output
mkdir -p packaging/root/usr/local/bin
go build -o packaging/root/usr/local/bin/drone  -ldflags "-X main.revision 1cb74a9" github.com/drone/drone/cli
go build -o packaging/root/usr/local/bin/droned -ldflags "-X main.revision 1cb74a9" github.com/drone/drone/server
# github.com/drone/drone/plugin/remote/bitbucket
plugin/remote/bitbucket/bitbucket.go:254: hook.Commits[len(hook.Commits) - 1].RawAuthor undefined (type *bitbucket.Commit has no field or method RawAuthor)
make: *** [build] Error 2
```

Could this be a typo? How build on drone.io got green?

//cc @gregory90 
