### PR TITLE
Fixes #448 missing live console output bug on rebuild

### DIFF
--- a/server/worker/docker/docker.go
+++ b/server/worker/docker/docker.go
@@ -68,7 +68,7 @@ func (d *Docker) Do(c context.Context, r *worker.Work) {
 	commitc := pubsub.Register(c, "_global")
 	commitc.Publish(r)
 	stdoutc := pubsub.RegisterOpts(c, r.Commit.ID, pubsub.ConsoleOpts)
-	defer stdoutc.Close()
+	defer pubsub.Unregister(c, r.Commit.ID)
 
 	// create a special buffer that will also
 	// write to a websocket channel


### PR DESCRIPTION
Hey there, I tried to fix the bug #448 with this commit. Since i looked today the first time at the codebase of this project, i am not 100% sure this is the correct solution.

The problem i saw was that when you force a rebuild, it gets stuck on:
server/pubsub/channel.go

``` go
func (c *Channel) Subscribe() *Subscription {
    s := NewSubscription(c)
    c.subscribe <- s //<--- stuck here
    return s
}
```

because the Channel was only closed, but not removed.

When you issue a new rebuild, it well return the old channel. But since the start loop is not running anymore, `c.subscribe <- s` gets stuck because the value is not getting pulled out of the queue from the start() loop.

So now i unregister the channel at the end of the build instead of just closing it.

Hope this helps

Best regards

David
