### PR TITLE
Affix the sidebar

### DIFF
--- a/server/app/styles/drone.less
+++ b/server/app/styles/drone.less
@@ -1229,6 +1229,11 @@ nav {
 	//border-left:1px solid #cdcece;
 	//box-shadow:-3px 0 0 rgba(0,0,0,.05);
 
+	#sidebar-inner {
+		position: fixed;
+		width: 180px;
+	}
+
 	h1 {font-size:28px; font-weight:300;}
 	h2 {font-size:22px; font-weight:300; margin-bottom:20px;}
 	dl {padding-top:23px; border-top:1px solid #ddd; margin-top:5px;

--- a/server/app/views/commit.html
+++ b/server/app/views/commit.html
@@ -1,37 +1,39 @@
 <aside id="sidebar">
-	<div class="result" data-result="{{ commit.status }}">
-		<dl>
-			<dd><span class="status">{{ commit.status }}</span></dd>
-			<dd><strong>{{ commit.message }}</strong></dd>
-		</dl>
-	</div>
-		
-	<dl ng-if="commit.duration != 0">
-		<dd><h1>{{ commit.duration | toDuration}}</h1></dd>
-	</dl>
+	<div id="sidebar-inner">
+		<div class="result" data-result="{{ commit.status }}">
+			<dl>
+				<dd><span class="status">{{ commit.status }}</span></dd>
+				<dd><strong>{{ commit.message }}</strong></dd>
+			</dl>
+		</div>
 
-	<dl>
-		<dd class="large" ng-if="repo.remote == 'gitlab.com' || repo.remote == 'github.com' || repo.remote == 'enterprise.github.com' ">
-			<strong>
-				commit 
-				<a href="http://{{ repo.host }}/{{ repo.owner }}/{{ repo.name }}/commit/{{ commit.sha }}" >{{ commit.sha | shortHash}}</a> 
-				to <a href="http://{{ repo.host }}/{{ repo.owner }}/{{ repo.name }}/tree/{{ commit.branch }}">{{ commit.branch }}</a> branch
-			</strong>
-		</dd>
-		<dd class="large" ng-if="repo.remote == 'bitbucket.org' ">
-			<strong>
-				commit 
-				<a href="http://{{ repo.host }}/{{ repo.owner }}/{{ repo.name }}/commits/{{ commit.sha }}" >{{ commit.sha | shortHash}}</a> 
-				to <a href="http://{{ repo.host }}/{{ repo.owner }}/{{ repo.name }}/src/?at={{ commit.branch }}">{{ commit.branch }}</a> branch
-			</strong>
-		</dd>
-		<dd class="large" ng-if="repo.remote != 'gitlab.com' && repo.remote != 'github.com' && repo.remote != 'enterprise.github.com' && repo.remote != 'bitbucket.org' ">
-			<strong>commit <u>{{ commit.sha | shortHash}}</u> to <u>{{ commit.branch }}</u> branch</strong>
-		</dd>
-		<dd ng-if="commit.finished_at != 0">{{ commit.finished_at | fromNow }}</dd>
-		<dd ng-if="commit.finished_at == 0 && commit.started_at != 0">Started {{ commit.started_at | fromNow }}</dd>
-		<dd ng-if="commit.finished_at == 0 && commit.started_at == 0">Created {{ commit.created_at}}</dd>
-	</dl>
+		<dl ng-if="commit.duration != 0">
+			<dd><h1>{{ commit.duration | toDuration}}</h1></dd>
+		</dl>
+
+		<dl>
+			<dd class="large" ng-if="repo.remote == 'gitlab.com' || repo.remote == 'github.com' || repo.remote == 'enterprise.github.com' ">
+				<strong>
+					commit 
+					<a href="http://{{ repo.host }}/{{ repo.owner }}/{{ repo.name }}/commit/{{ commit.sha }}" >{{ commit.sha | shortHash}}</a> 
+					to <a href="http://{{ repo.host }}/{{ repo.owner }}/{{ repo.name }}/tree/{{ commit.branch }}">{{ commit.branch }}</a> branch
+				</strong>
+			</dd>
+			<dd class="large" ng-if="repo.remote == 'bitbucket.org' ">
+				<strong>
+					commit 
+					<a href="http://{{ repo.host }}/{{ repo.owner }}/{{ repo.name }}/commits/{{ commit.sha }}" >{{ commit.sha | shortHash}}</a> 
+					to <a href="http://{{ repo.host }}/{{ repo.owner }}/{{ repo.name }}/src/?at={{ commit.branch }}">{{ commit.branch }}</a> branch
+				</strong>
+			</dd>
+			<dd class="large" ng-if="repo.remote != 'gitlab.com' && repo.remote != 'github.com' && repo.remote != 'enterprise.github.com' && repo.remote != 'bitbucket.org' ">
+				<strong>commit <u>{{ commit.sha | shortHash}}</u> to <u>{{ commit.branch }}</u> branch</strong>
+			</dd>
+			<dd ng-if="commit.finished_at != 0">{{ commit.finished_at | fromNow }}</dd>
+			<dd ng-if="commit.finished_at == 0 && commit.started_at != 0">Started {{ commit.started_at | fromNow }}</dd>
+			<dd ng-if="commit.finished_at == 0 && commit.started_at == 0">Created {{ commit.created_at}}</dd>
+		</dl>
+        </div>
 </aside>
 
 <div id="main" class="output">


### PR DESCRIPTION
This fixes the sidebar so that it does not scroll with the log.

![drone-affix-sidebar](https://cloud.githubusercontent.com/assets/103167/4798510/7c6db04e-5e14-11e4-9bc4-78a90175751f.png)

The diff looks weird in GitHub (turning off whitespace [cleans it up](https://github.com/drone/drone/pull/636/files?w=1)), but the only new tag is the `<div id="sidebar-inner">` wrapping everything inside `<aside id="sidebar">`. I don't think there is a way to use `position: fixed` and the `#main { flex-grow: 2 }` rules together without creating this new tag.

If you'd like any semantics different from `id=sidebar-inner`, etc. let me know.
