### PR TITLE
fix badge branch selection

### DIFF
--- a/server/handler/badge.go
+++ b/server/handler/badge.go
@@ -33,7 +33,7 @@ func GetBadge(c web.C, w http.ResponseWriter, r *http.Request) {
 		host   = c.URLParams["host"]
 		owner  = c.URLParams["owner"]
 		name   = c.URLParams["name"]
-		branch = c.URLParams["branch"]
+		branch = r.FormValue("branch")
 	)
 
 	// an SVG response is always served, even when error, so


### PR DESCRIPTION
Fix the badge handler to retrieve the branch from the query and not from the URL parameters.
