### PR TITLE
Add verbose user repo feed

### DIFF
--- a/server/datastore/database/commit.go
+++ b/server/datastore/database/commit.go
@@ -113,7 +113,6 @@ WHERE c.repo_id = r.repo_id
 	WHERE c.repo_id = r.repo_id
 	  AND r.repo_id = p.repo_id
 	  AND p.user_id = ?
-	  AND c.commit_status NOT IN ('Started', 'Pending')
 	GROUP BY r.repo_id
 ) ORDER BY c.commit_created DESC LIMIT 5;
 `

--- a/server/datastore/database/commit_test.go
+++ b/server/datastore/database/commit_test.go
@@ -203,9 +203,16 @@ func TestCommitstore(t *testing.T) {
 				Sha:    "0a74b46d7d62b737b6906897f48dbeb72cfda222",
 				Status: model.StatusSuccess,
 			}
+			commit4 := model.Commit{
+				RepoID: repo2.ID,
+				Branch: "bar",
+				Sha:    "d923a61d8ad3d8d02db4fef0bf40a726bad0fc03",
+				Status: model.StatusStarted,
+			}
 			cs.PostCommit(&commit1)
 			cs.PostCommit(&commit2)
 			cs.PostCommit(&commit3)
+			cs.PostCommit(&commit4)
 			perm1 := model.Perm{
 				RepoID: repo1.ID,
 				UserID: 1,
@@ -228,6 +235,8 @@ func TestCommitstore(t *testing.T) {
 			g.Assert(commits[0].RepoID).Equal(commit1.RepoID)
 			g.Assert(commits[0].Branch).Equal(commit1.Branch)
 			g.Assert(commits[0].Sha).Equal(commit1.Sha)
+			g.Assert(commits[1].Sha).Equal(commit4.Sha)
+			g.Assert(commits[1].Status).Equal(commit4.Status)
 		})
 
 		g.It("Should enforce unique Sha + Branch", func() {


### PR DESCRIPTION
@bradrydzewski This is the only necessary piece for getting the refreshed drone-wall up to speed on 0.3. @Tathanen is working on getting that side refactored so we can push it out.

I'm open to suggestions on the design since this is a little hamfisted. We basically just need to get the `/api/user/feed` but also including Pending and Started builds. I've done this with an additional `/api/user/feed/verbose` endpoint that also extends the result limit to 20. We do a ton of build traffic at Vokal so the fatter response is something we've found to be necessary.

Indirectly fixes https://github.com/drone/drone-wall/issues/10
