### PR TITLE
swap url and linktext positions for slack

### DIFF
--- a/plugin/notify/slack.go
+++ b/plugin/notify/slack.go
@@ -42,7 +42,7 @@ func (s *Slack) getMessage(context *model.Request, message string) string {
 	// drone/drone#3333333
 	linktext := context.Repo.Owner + "/" + context.Repo.Name + "#" + context.Commit.ShaShort()
 
-	return fmt.Sprintf(message, linktext, url, context.Commit.Branch, context.Commit.Author)
+	return fmt.Sprintf(message, url, linktext, context.Commit.Branch, context.Commit.Author)
 }
 
 func (s *Slack) sendStarted(context *model.Request) error {

--- a/plugin/notify/slack_test.go
+++ b/plugin/notify/slack_test.go
@@ -23,7 +23,7 @@ var request = &model.Request{
 }
 */
 
-var slackExpectedLink = "<owner/repo#abc|http://examplehost.com/examplegit.com/owner/repo/example/abc>"
+var slackExpectedLink = "<http://examplehost.com/examplegit.com/owner/repo/example/abc|owner/repo#abc>"
 var slackExpectedBase = slackExpectedLink + " (example) by Test User"
 
 func Test_slackStartedMessage(t *testing.T) {


### PR DESCRIPTION
The slack url format is `<url|linktext>`; it's currently reversed (introduced in https://github.com/drone/drone/commit/0a0151fa5e988ec8e117c91fa66b40803b861e9c).
