### PR TITLE
Add gogs support

### DIFF
--- a/plugin/remote/gogs/gogs.go
+++ b/plugin/remote/gogs/gogs.go
@@ -1,0 +1,183 @@
+package gogs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/drone/drone/shared/model"
+	"github.com/gogits/go-gogs-client"
+)
+
+type Gogs struct {
+	URL    string
+	Secret string
+}
+
+func New(url string, secret string) *Gogs {
+	return &Gogs{URL: url, Secret: secret}
+}
+
+// Authorize handles Gogs authorization
+func (r *Gogs) Authorize(res http.ResponseWriter, req *http.Request) (*model.Login, error) {
+	var username = req.FormValue("username")
+	var password = req.FormValue("password")
+	var client = gogs.NewClient(r.URL, "")
+
+	// try to fetch drone token if it exists
+	var accessToken = ""
+	tokens, err := client.ListAccessTokens(username, password)
+	if err != nil {
+		return nil, err
+	}
+	for _, token := range tokens {
+		if token.Name == "drone" {
+			accessToken = token.Sha1
+			break
+		}
+	}
+
+	// if drone token not found, create it
+	if accessToken == "" {
+		token, err := client.CreateAccessToken(username, password, gogs.CreateAccessTokenOption{Name: "drone"})
+		if err != nil {
+			return nil, err
+		}
+		accessToken = token.Sha1
+	}
+
+	// update client
+	client = gogs.NewClient(r.URL, accessToken)
+
+	// fetch user information
+	user, err := client.GetUserInfo(username)
+	if err != nil {
+		return nil, err
+	}
+
+	var login = new(model.Login)
+	login.Name = user.FullName
+	login.Email = user.Email
+	login.Access = accessToken
+	login.Login = username
+	return login, nil
+}
+
+// GetKind returns the internal identifier of this remote Gogs instance
+func (r *Gogs) GetKind() string {
+	return model.RemoteGogs
+}
+
+// GetHost returns the hostname of this remote Gogs instance
+func (r *Gogs) GetHost() string {
+	uri, _ := url.Parse(r.URL)
+	return uri.Host
+}
+
+// GetRepos fetches all repositories that the specified
+// user has access to in the remote system.
+func (r *Gogs) GetRepos(user *model.User) ([]*model.Repo, error) {
+	var repos []*model.Repo
+
+	var remote = r.GetKind()
+	var hostname = r.GetHost()
+	var client = gogs.NewClient(r.URL, user.Access)
+
+	gogsRepos, err := client.ListMyRepos()
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, repo := range gogsRepos {
+		var repoName = strings.Split(repo.FullName, "/")
+		if len(repoName) < 2 {
+			log.Println("invalid repo full_name", repo.FullName)
+			continue
+		}
+		var owner = repoName[0]
+		var name = repoName[1]
+
+		var repo = model.Repo{
+			UserID:   user.ID,
+			Remote:   remote,
+			Host:     hostname,
+			Owner:    owner,
+			Name:     name,
+			Private:  repo.Private,
+			CloneURL: repo.CloneUrl,
+			GitURL:   repo.CloneUrl,
+			SSHURL:   repo.SshUrl,
+			URL:      repo.HtmlUrl,
+			Role: &model.Perm{
+				Admin: repo.Permissions.Admin,
+				Write: repo.Permissions.Push,
+				Read:  repo.Permissions.Pull,
+			},
+		}
+
+		repos = append(repos, &repo)
+	}
+
+	return repos, err
+}
+
+// GetScript fetches the build script (.drone.yml) from the remote
+// repository and returns a byte array
+func (r *Gogs) GetScript(user *model.User, repo *model.Repo, hook *model.Hook) ([]byte, error) {
+	var client = gogs.NewClient(r.URL, user.Access)
+	return client.GetFile(repo.Owner, repo.Name, hook.Sha, ".drone.yml")
+}
+
+// Activate activates a repository
+func (r *Gogs) Activate(user *model.User, repo *model.Repo, link string) error {
+	var client = gogs.NewClient(r.URL, user.Access)
+
+	var config = map[string]string{
+		"url":          link,
+		"secret":       r.Secret,
+		"content_type": "json",
+	}
+	var hook = gogs.CreateHookOption{
+		Type:   "gogs",
+		Config: config,
+		Active: true,
+	}
+
+	_, err := client.CreateRepoHook(repo.Owner, repo.Name, hook)
+	return err
+}
+
+// ParseHook parses the post-commit hook from the Request body
+// and returns the required data in a standard format.
+func (r *Gogs) ParseHook(req *http.Request) (*model.Hook, error) {
+	defer req.Body.Close()
+	var payloadbytes, _ = ioutil.ReadAll(req.Body)
+	var payload, err = gogs.ParseHook(payloadbytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// verify the payload has the minimum amount of required data.
+	if payload.Repo == nil || payload.Commits == nil || len(payload.Commits) == 0 {
+		return nil, fmt.Errorf("Invalid Gogs post-commit Hook. Missing Repo or Commit data.")
+	}
+
+	if payload.Secret != r.Secret {
+		return nil, fmt.Errorf("Payload secret does not match stored secret")
+	}
+
+	return &model.Hook{
+		Owner:     payload.Repo.Owner.UserName,
+		Repo:      payload.Repo.Name,
+		Sha:       payload.Commits[0].Id,
+		Branch:    payload.Branch(),
+		Author:    payload.Commits[0].Author.UserName,
+		Timestamp: time.Now().UTC().String(),
+		Message:   payload.Commits[0].Message,
+	}, nil
+}

--- a/plugin/remote/gogs/register.go
+++ b/plugin/remote/gogs/register.go
@@ -1,0 +1,23 @@
+package gogs
+
+import (
+	"github.com/drone/config"
+	"github.com/drone/drone/plugin/remote"
+)
+
+var (
+	gogsUrl    = config.String("gogs-url", "")
+	gogsSecret = config.String("gogs-secret", "")
+)
+
+// Registers the Gogs plugin using the default
+// settings from the config file or environment
+// variables.
+func Register() {
+	if len(*gogsUrl) == 0 {
+		return
+	}
+	remote.Register(
+		New(*gogsUrl, *gogsSecret),
+	)
+}

--- a/server/app/scripts/app.js
+++ b/server/app/scripts/app.js
@@ -52,6 +52,10 @@ app.config(['$routeProvider', '$locationProvider', '$httpProvider', function($ro
 			templateUrl: '/static/views/login_gitlab.html',
 			title: 'GitLab Login',
 		})
+		.when('/gogs', {
+			templateUrl: '/static/views/login_gogs.html',
+			title: 'Gogs Setup',
+		})
 		.when('/setup', {
 			templateUrl: '/static/views/setup.html',
 			controller: 'SetupController',
@@ -234,6 +238,6 @@ app.controller("AccountReposController", function($scope, $http, $location, user
 			return true;
 		};
 	$scope.byRemote = function(entry){
-			return $scope.remote == "" || $scope.remote == entry.remote; 
-		}; 
+			return $scope.remote == "" || $scope.remote == entry.remote;
+		};
 });

--- a/server/app/scripts/controllers/conf.js
+++ b/server/app/scripts/controllers/conf.js
@@ -30,6 +30,9 @@ angular.module('app').controller("ConfigController", function($scope, $http, rem
 				case 'stash.atlassian.com':
 					$scope.stash = remote;
 					break;
+				case 'gogs':
+					$scope.gogs = remote;
+					break;
 				}
 			}
 		})

--- a/server/app/scripts/filters/filters.js
+++ b/server/app/scripts/filters/filters.js
@@ -144,6 +144,7 @@
       case 'enterprise.github.com' : return 'GitHub Enterprise';
       case 'bitbucket.org'         : return 'Bitbucket';
       case 'stash.atlassian.com'   : return 'Atlassian Stash';
+      case 'gogs'                  : return 'Gogs';
       }
     }
   }
@@ -160,6 +161,7 @@
       case 'enterprise.github.com' : return 'fa-github-square';
       case 'bitbucket.org'         : return 'fa-bitbucket-square';
       case 'stash.atlassian.com'   : return 'fa-bitbucket-square';
+      case 'gogs'                  : return 'fa-git-square';
       }
     }
   }

--- a/server/app/views/commit_detail.html
+++ b/server/app/views/commit_detail.html
@@ -16,8 +16,17 @@
 	</strong>
 </dd>
 <!-- /BITBUCKET -->
+<!-- GOGS -->
+<dd class="large" ng-if="repo.remote == 'gogs' ">
+	<strong>
+		commit 
+		<a href="{{ repo.url }}/commit/{{ commit.sha }}" >{{ commit.sha | shortHash}}</a> 
+		to <a href="{{ repo.url }}/src/{{ commit.branch }}">{{ commit.branch }}</a> branch
+	</strong>
+</dd>
+<!-- /GOGS -->
 <!-- STASH -->
-<dd class="large" ng-if="repo.remote != 'gitlab.com' && repo.remote != 'github.com' && repo.remote != 'enterprise.github.com' && repo.remote != 'bitbucket.org' ">
+<dd class="large" ng-if="repo.remote != 'gitlab.com' && repo.remote != 'github.com' && repo.remote != 'enterprise.github.com' && repo.remote != 'bitbucket.org' && repo.remote != 'gogs' ">
 	<strong>commit <u>{{ commit.sha | shortHash}}</u> to <u>{{ commit.branch }}</u> branch</strong>
 </dd>
 <!-- /STASH -->

--- a/server/app/views/config.html
+++ b/server/app/views/config.html
@@ -16,14 +16,14 @@
 						</div>
 					</div>
 
-					<div ng-if="remote.type != 'github.com' && remote.type != 'bitbucket.org' ">
+					<div ng-if="remote.type != 'github.com' && remote.type != 'bitbucket.org' && remote.type != 'gogs' ">
 						<label>API URL</label>
 						<div ng-switch="remote.type">
 							<input ng-switch-default ng-model="remote.api" type="text" placeholder="https://www.foo.com/api" />
 						</div>
 					</div>
 
-					<div ng-if="remote.type != 'gitlab.com'">
+					<div ng-if="remote.type != 'gitlab.com' && remote.type != 'gogs' ">
 						<label>OAuth Client</label>
 						<div>
 							<input type="text" ng-model="remote.client" />

--- a/server/app/views/login.html
+++ b/server/app/views/login.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 minor modifications to the style that only apply to this view
 -->
 <style>
@@ -11,10 +11,13 @@ minor modifications to the style that only apply to this view
 <article id="loginpage">
 	<div class="pure-g">
 		<div class="pure-u-1" ng-if="state == 1 && remotes.length != 0" ng-repeat="remote in remotes">
-			<a ng-href="/api/auth/{{ remote.type }}" target="_self" ng-if="remote.type != 'gitlab.com' ">
+			<a ng-href="/api/auth/{{ remote.type }}" target="_self" ng-if="remote.type != 'gitlab.com' && remote.type != 'gogs' ">
 				<i class="fa {{ remote.type | remoteIcon }}"></i> {{ remote.type | remoteName }}
 			</a>
 			<a ng-href="/gitlab" ng-if="remote.type == 'gitlab.com' ">
+				<i class="fa {{ remote.type | remoteIcon }}"></i> {{ remote.type | remoteName }}
+			</a>
+			<a ng-href="/gogs" ng-if="remote.type == 'gogs' ">
 				<i class="fa {{ remote.type | remoteIcon }}"></i> {{ remote.type | remoteName }}
 			</a>
 		</div>

--- a/server/app/views/login_gogs.html
+++ b/server/app/views/login_gogs.html
@@ -1,0 +1,23 @@
+<!--
+minor modifications to the style that only apply to this view
+-->
+<style>
+#container { padding-top: 155px; }
+#header { height: 150px; }
+#header .user { display:none; }
+#header .brand { margin-top:55px ; }
+</style>
+
+<article id="loginpage">
+	<form class="pure-g" method="POST" action="/api/auth/gogs">
+		<div class="pure-u-1">
+			<input type="text" name="username" placeholder="Username" />
+		</div>
+		<div class="pure-u-1">
+			<input type="password" name="password" placeholder="Password" />
+		</div>
+		<div class="pure-u-1">
+			<input type="submit" value="Gogs Login" />
+		</div>
+	</form>
+</article>

--- a/server/app/views/users_add.html
+++ b/server/app/views/users_add.html
@@ -25,6 +25,7 @@
 							<option value="gitlab.com">GitLab</option>
 							<option value="bitbucket.org">Bitbucket</option>
 							<option value="stash.atlassian.com">Stash</option>
+							<option value="gogs">Gogs</option>
 						</select>
 
 						<label for="username">Username</label>

--- a/server/main.go
+++ b/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/drone/drone/plugin/remote/bitbucket"
 	"github.com/drone/drone/plugin/remote/github"
 	"github.com/drone/drone/plugin/remote/gitlab"
+	"github.com/drone/drone/plugin/remote/gogs"
 	"github.com/drone/drone/server/blobstore"
 	"github.com/drone/drone/server/capability"
 	"github.com/drone/drone/server/datastore"
@@ -97,6 +98,7 @@ func main() {
 	bitbucket.Register()
 	github.Register()
 	gitlab.Register()
+	gogs.Register()
 
 	caps = map[string]bool{}
 	caps[capability.Registration] = *open

--- a/shared/model/remote.go
+++ b/shared/model/remote.go
@@ -6,6 +6,7 @@ const (
 	RemoteGithubEnterprise = "enterprise.github.com"
 	RemoteBitbucket        = "bitbucket.org"
 	RemoteStash            = "stash.atlassian.com"
+	RemoteGogs             = "gogs"
 )
 
 type Remote struct {


### PR DESCRIPTION
I've attempted to add some basic support for adding [gogs](https://github.com/gogits/gogs/) repos to be tested via drone.

There's no API for accessing gogs internals so a few concessions were made:
1. Need to scrape HTML gogs produces to pull the repo names
2. As a result, only public repos can be added.
3. Need to manually add the hook url via Gogs UI for any activated drone repo.

For 3, I've added some code to show the expected Gogs payload URL including the token whenever a gogs repo is activated. This is also displayed under the repo settings for the gogs remote. I needed to make a few changes to expose this token.

In your `.drone.toml`, you'll need to add a new setting, e.g.:

```
[gogs]
url="https://gogs.example.com"
```

When authorizing in drone, the username you provide should be the username the repos can be found under.

Let me know of any feedback and I will incorporate!
