### PR TITLE
Add hostname in docker section of .drone.yml

### DIFF
--- a/shared/build/build.go
+++ b/shared/build/build.go
@@ -319,6 +319,7 @@ func (b *Builder) teardown() error {
 func (b *Builder) run() error {
 	// create and run the container
 	conf := docker.Config{
+		Hostname:     script.DockerHostname(b.Build.Docker),
 		Image:        b.image.ID,
 		AttachStdin:  false,
 		AttachStdout: true,

--- a/shared/build/script/docker.go
+++ b/shared/build/script/docker.go
@@ -10,6 +10,10 @@ type Docker struct {
     // NetworkMode (also known as `--net` option)
     // Could be set only if Docker is running in privileged mode
     NetworkMode *string `yaml:"net,omitempty"`
+
+    // Hostname (also known as `--hostname` option)
+    // Could be set only if Docker is running in privileged mode
+    Hostname *string `yaml:"hostname,omitempty"`
 }
 
 // DockerNetworkMode returns DefaultNetworkMode
@@ -21,4 +25,15 @@ func DockerNetworkMode(d *Docker) string {
         return DefaultDockerNetworkMode
     }
     return *d.NetworkMode
+}
+
+// DockerNetworkMode returns empty string
+// when Docker.NetworkMode is empty.
+// DockerNetworkMode returns Docker.NetworkMode
+// when it is not empty.
+func DockerHostname(d *Docker) string {
+    if d == nil || d.Hostname == nil {
+        return ""
+    }
+    return *d.Hostname
 }

--- a/shared/build/script/docker_test.go
+++ b/shared/build/script/docker_test.go
@@ -38,3 +38,32 @@ func TestDockerNetworkMode(t *testing.T) {
         t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
     }
 }
+
+func TestDockerHostname(t *testing.T) {
+    var d *Docker
+    var expected string
+
+    expected = ""
+    d = nil
+    if actual := DockerHostname(d); actual != expected {
+        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+    }
+
+    expected = ""
+    d = &Docker{}
+    if actual := DockerHostname(d); actual != expected {
+        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+    }
+
+    expected = ""
+    d = &Docker{Hostname: nil}
+    if actual := DockerHostname(d); actual != expected {
+        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+    }
+
+    expected = "host"
+    d = &Docker{Hostname: &expected}
+    if actual := DockerHostname(d); actual != expected {
+        t.Errorf("The result is invalid. [expected: %s][actual: %s]", expected, actual)
+    }
+}


### PR DESCRIPTION
Turns out, that setup of `/etc/hosts` in docker from the running container is [hacky](http://unix.stackexchange.com/a/57464). But `docker` have `-h --hostname` option, that will setup right hostname for you.
