### PR TITLE
Update drone.toml

### DIFF
--- a/packaging/root/etc/drone/drone.toml
+++ b/packaging/root/etc/drone/drone.toml
@@ -11,7 +11,7 @@ port=":80"
 
 # [session]
 # secret=""
-# duration=""
+# expires=""
 
 #####################################################################
 # Database configuration, by default using SQLite3.


### PR DESCRIPTION
Run droned throw this error message: `Unable to parse config: no such flag -session-duration`
