### PR TITLE
`drone build --deploy` doesn't work as expected

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -127,10 +127,10 @@ func run(path, identity, dockerhost, dockercert, dockerkey string, publish, depl
 	}
 
 	if deploy == false {
-		s.Publish = nil
+		s.Deploy = nil
 	}
 	if publish == false {
-		s.Deploy = nil
+		s.Publish = nil
 	}
 
 	// get the repository root directory


### PR DESCRIPTION
I found it doesn't trigger deployment at all until I use flag `--publish` which should be flag `--deploy`.

These two flags were introduced in commit afc3030087260b51f901b9f674c0d6a9d7b01bb7 in #541 and I didn't try to use them until today
