### PR TITLE
parse build file with params injection

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -115,7 +115,7 @@ func run(path, identity, dockerhost, dockercert, dockerkey string, publish, depl
 	envs := getParamMap("DRONE_ENV_")
 
 	// parse the Drone yml file
-	s, err := script.ParseBuildFile(script.Inject(path, envs))
+	s, err := script.ParseBuildFile(path, envs)
 	if err != nil {
 		log.Err(err.Error())
 		return EXIT_STATUS, err

--- a/shared/build/script/script.go
+++ b/shared/build/script/script.go
@@ -22,13 +22,13 @@ func ParseBuild(data string) (*Build, error) {
 	return &build, err
 }
 
-func ParseBuildFile(filename string) (*Build, error) {
+func ParseBuildFile(filename string, params map[string]string) (*Build, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	return ParseBuild(string(data))
+	return ParseBuild(Inject(string(data), params))
 }
 
 // Build stores the configuration details for


### PR DESCRIPTION
the injected parameters like `$$HEROKU_TOKEN` doesn't work in `.drone.yml` (but works via environment variable `$HEROKU_TOKEN`).

Then I realized that when verifying #541, I just confirmed the new syntax `$$` within environment variable but not in `drone.yml` until today.
