### PR TITLE
Fix the IRC notification plugin.

### DIFF
--- a/plugin/notify/irc/irc.go
+++ b/plugin/notify/irc/irc.go
@@ -66,7 +66,7 @@ func (i *IRC) send(channel string, message string) error {
 
 	client.AddCallback("001", func(_ *irc.Event) {
 		client.Notice(channel, message)
-		client.Disconnect()
+		client.Quit()
 	})
 
 	go client.Loop()


### PR DESCRIPTION
This fixes the IRC notification plugin to wait for the connection to finish before sending the notification.

Additionally, it fixes a broken error check in the initalisation system.
