### PR TITLE
Make Heroku destination refspec more specific.

### DIFF
--- a/plugin/deploy/heroku/heroku.go
+++ b/plugin/deploy/heroku/heroku.go
@@ -44,10 +44,10 @@ func (h *Heroku) Write(f *buildfile.Buildfile) {
 		// that need to be deployed to Heroku.
 		f.WriteCmd(fmt.Sprintf("git add -A"))
 		f.WriteCmd(fmt.Sprintf("git commit -m 'adding build artifacts'"))
-		f.WriteCmd(fmt.Sprintf("git push heroku HEAD:master --force"))
+		f.WriteCmd(fmt.Sprintf("git push heroku HEAD:refs/heads/master --force"))
 	case false:
 		// otherwise we just do a standard git push
-		f.WriteCmd(fmt.Sprintf("git push heroku $COMMIT:master"))
+		f.WriteCmd(fmt.Sprintf("git push heroku $COMMIT:refs/heads/master"))
 	}
 }
 

--- a/plugin/deploy/heroku/heroku_test.go
+++ b/plugin/deploy/heroku/heroku_test.go
@@ -57,7 +57,7 @@ func Test_Heroku(t *testing.T) {
 
 			d.Write(b)
 			out := b.String()
-			g.Assert(strings.Contains(out, "\ngit push heroku $COMMIT:master\n")).Equal(true)
+			g.Assert(strings.Contains(out, "\ngit push heroku $COMMIT:refs/heads/master\n")).Equal(true)
 		})
 
 		g.It("Should force push to remote", func() {
@@ -71,7 +71,7 @@ func Test_Heroku(t *testing.T) {
 			out := b.String()
 			g.Assert(strings.Contains(out, "\ngit add -A\n")).Equal(true)
 			g.Assert(strings.Contains(out, "\ngit commit -m 'adding build artifacts'\n")).Equal(true)
-			g.Assert(strings.Contains(out, "\ngit push heroku HEAD:master --force\n")).Equal(true)
+			g.Assert(strings.Contains(out, "\ngit push heroku HEAD:refs/heads/master --force\n")).Equal(true)
 		})
 
 	})


### PR DESCRIPTION
Pushing to a new Heroku application (not pushed to yet) was failing with the below output.  Making the refspec more specific allowed the push to go through.

``` bash
$ git push heroku HEAD:master --force
Initializing repository, done.
error: unable to push to unqualified destination: master
The destination refspec neither matches an existing ref on the remote nor
begins with refs/, and we are unable to guess a prefix based on the source ref.
error: failed to push some refs to 'git@heroku.com:application-name.git'

```
