### PR TITLE
Added "DEBIAN_FRONTEND=noninteractive" to list of default environment variables.

### DIFF
--- a/operator/runner/env.go
+++ b/operator/runner/env.go
@@ -30,6 +30,7 @@ func systemEnviron(system *core.System) map[string]string {
 		"DRONE_SYSTEM_HOST":     system.Host,
 		"DRONE_SYSTEM_HOSTNAME": system.Host,
 		"DRONE_SYSTEM_VERSION":  fmt.Sprint(system.Version),
+		"DEBIAN_FRONTEND":       "noninteractive",
 	}
 }
 


### PR DESCRIPTION
All Drone CI builds are run in an automated manner that doesn't accept user input.

Therefore, it would be desirable if, when installing packages with `apt`, that it *defaults* to running without user prompts.

This can currently be done if the flag is manually set in a build file, but I don't see any reason why it shouldn't be a global default (besides maybe being platform-specific to Debian systems, but Debian's quite widely used).