### PR TITLE
Drone Version Bump from 2.24.0 to 2.25.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -25,7 +25,7 @@ var (
 	// VersionMajor is for an API incompatible changes.
 	VersionMajor int64 = 2
 	// VersionMinor is for functionality in a backwards-compatible manner.
-	VersionMinor int64 = 24
+	VersionMinor int64 = 25
 	// VersionPatch is for backwards-compatible bug fixes.
 	VersionPatch int64 = 0
 	// VersionPre indicates prerelease.

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -10,7 +10,7 @@ package version
 import "testing"
 
 func TestVersion(t *testing.T) {
-	if got, want := Version.String(), "2.24.0"; got != want {
+	if got, want := Version.String(), "2.25.0"; got != want {
 		t.Errorf("Want version %s, got %s", want, got)
 	}
 }


### PR DESCRIPTION
Security vulns fixed as part of PR #3577. Releasing new minor release 2.25.0.