### PR TITLE
Fixing the comment handling for devcontainer.json file.

### DIFF
--- a/app/gitspace/scm/scm.go
+++ b/app/gitspace/scm/scm.go
@@ -26,6 +26,8 @@ import (
 	"github.com/harness/gitness/git/command"
 	"github.com/harness/gitness/types"
 	"github.com/harness/gitness/types/enum"
+
+	"github.com/tidwall/jsonc"
 )
 
 var (
@@ -100,13 +102,6 @@ func (s *SCM) GetSCMRepoDetails(
 		DevcontainerConfig:  devcontainerConfig,
 	}
 	return resolvedDetails, nil
-}
-
-func removeComments(input []byte) []byte {
-	blockCommentRegex := regexp.MustCompile(`(?s)/\*.*?\*/`)
-	input = blockCommentRegex.ReplaceAll(input, nil)
-	lineCommentRegex := regexp.MustCompile(`//.*`)
-	return lineCommentRegex.ReplaceAll(input, nil)
 }
 
 func detectDefaultGitBranch(ctx context.Context, gitRepoDir string) (string, error) {
@@ -192,8 +187,7 @@ func (s *SCM) getDevcontainerConfig(
 		return config, nil // Return an empty config if the file is empty
 	}
 
-	sanitizedJSON := removeComments(catFileOutputBytes)
-	if err = json.Unmarshal(sanitizedJSON, &config); err != nil {
+	if err = json.Unmarshal(jsonc.ToJSON(catFileOutputBytes), &config); err != nil {
 		return config, fmt.Errorf("failed to parse devcontainer JSON: %w", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v27.1.1+incompatible
 	github.com/docker/go-connections v0.5.0
+	github.com/docker/go-units v0.5.0
 	github.com/drone-runners/drone-runner-docker v1.8.4-0.20240815103043-c6c3a3e33ce3
 	github.com/drone/drone-go v1.7.1
 	github.com/drone/drone-yaml v1.2.3
@@ -71,6 +72,7 @@ require (
 	github.com/swaggest/swgui v1.8.1
 	github.com/swaggo/http-swagger v1.3.4
 	github.com/swaggo/swag v1.16.2
+	github.com/tidwall/jsonc v0.3.2
 	github.com/unrolled/secure v1.15.0
 	github.com/zricethezav/gitleaks/v8 v8.18.5-0.20240912004812-e93a7c0d2604
 	go.starlark.net v0.0.0-20231121155337-90ade8b19d09
@@ -106,7 +108,6 @@ require (
 	github.com/charmbracelet/lipgloss v0.12.1 // indirect
 	github.com/charmbracelet/x/ansi v0.1.4 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/drone/envsubst v1.0.3 // indirect
 	github.com/fatih/semgroup v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -762,6 +762,8 @@ github.com/swaggo/http-swagger v1.3.4 h1:q7t/XLx0n15H1Q9/tk3Y9L4n210XzJF5WtnDX64
 github.com/swaggo/http-swagger v1.3.4/go.mod h1:9dAh0unqMBAlbp1uE2Uc2mQTxNMU/ha4UbucIg1MFkQ=
 github.com/swaggo/swag v1.16.2 h1:28Pp+8DkQoV+HLzLx8RGJZXNGKbFqnuvSbAAtoxiY04=
 github.com/swaggo/swag v1.16.2/go.mod h1:6YzXnDcpr0767iOejs318CwYkCQqyGer6BizOg03f+E=
+github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
+github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=


### PR DESCRIPTION
Using the open-source `github.com/tidwall/jsonc` library to parse and filter out the comments.