### PR TITLE
Update ssh port mapping for docker command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install Harness yourself, simply run the command below. Once the container is
 ```bash
 docker run -d \
   -p 3000:3000 \
-  -p 22:22 \
+  -p 3022:3022 \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp/harness:/data \
   --name harness \


### PR DESCRIPTION
Addresses https://github.com/harness/harness/issues/3637

Update docker command in readme to use `3022:3022` instead of `22:22` just like the [devdocs](https://developer.harness.io/docs/open-source/installation/quick-start)

<img width="1508" height="480" alt="image" src="https://github.com/user-attachments/assets/a2f6e4c1-34b6-4bde-a138-c530723891a0" />
