### PR TITLE
types: using reflect.TypeFor

### DIFF
--- a/types/gitspace_settings.go
+++ b/types/gitspace_settings.go
@@ -165,8 +165,8 @@ type InfraProviderSettings struct {
 }
 
 var settingsTypeRegistry = map[enum.GitspaceSettingsType]reflect.Type{
-	enum.SettingsTypeInfraProvider:  reflect.TypeOf(InfraProviderSettings{}),
-	enum.SettingsTypeGitspaceConfig: reflect.TypeOf(GitspaceConfigSettings{}),
+	enum.SettingsTypeInfraProvider:  reflect.TypeFor[InfraProviderSettings](),
+	enum.SettingsTypeGitspaceConfig: reflect.TypeFor[GitspaceConfigSettings](),
 }
 
 func DecodeSettings[T any](data map[string]any) (*T, error) {


### PR DESCRIPTION
**why you might use `reflect.TypeFor` instead of `reflect.TypeOf` in Go**.

---

### **Background**
In Go, the `reflect` package provides two similar-looking functions:

- **`reflect.TypeOf(x)`**  
  Takes a value `x` and returns its `reflect.Type`.  
  Example:  
  ```go
  t := reflect.TypeOf(123) // type: int
  ```

- **`reflect.TypeFor[T]()`** *(introduced in Go 1.22)*  
  A generic function that returns the `reflect.Type` for a type parameter `T` **without needing a value**.  
  Example:  
  ```go
  t := reflect.TypeFor[int]() // type: int
  ```

---

### **Why use `reflect.TypeFor` instead of `reflect.TypeOf`?**

1. **No value needed**  
   - `reflect.TypeOf` requires an actual value at runtime.  
     If you only know the type (not a value), you have to create a dummy value:
     ```go
     t := reflect.TypeOf((*MyStruct)(nil)).Elem()
     ```
   - `reflect.TypeFor` works directly with the type parameter:
     ```go
     t := reflect.TypeFor[MyStruct]()
     ```
     This is cleaner and avoids allocating or creating dummy values.

2. **Compile-time type safety**  
   - With `reflect.TypeOf`, the type is determined from a runtime value, so mistakes may only show up at runtime.
   - With `reflect.TypeFor`, the type is determined at compile time from the generic type parameter, so it’s safer and clearer.

3. **Better for generic code**  
   - In generic functions, you often have a type parameter `T` but no value of type `T`.  
     `reflect.TypeOf` can’t be used without creating a zero value:
     ```go
     func PrintType[T any]() {
         var zero T
         fmt.Println(reflect.TypeOf(zero))
     }
     ```
     With `reflect.TypeFor`, you can simply do:
     ```go
     func PrintType[T any]() {
         fmt.Println(reflect.TypeFor[T]())
     }
     ```

4. **Avoids unnecessary allocations**  
   - Creating a dummy value for `reflect.TypeOf` may allocate memory (especially for composite types).  
   - `reflect.TypeFor` avoids this overhead entirely.

---

### **Summary Table**

| Feature                  | `reflect.TypeOf`                  | `reflect.TypeFor` (Go 1.22+) |
|--------------------------|------------------------------------|------------------------------|
| Requires a value         | ✅ Yes                             | ❌ No                        |
| Works without allocation | ❌ Sometimes allocates             | ✅ Yes                       |
| Compile-time type safety | ❌ Runtime only                    | ✅ Compile-time              |
| Good for generics        | ❌ Needs zero value                | ✅ Directly works            |

---

✅ **Recommendation:**  
Use `reflect.TypeFor` when:
- You know the type at compile time (especially in generic code).
- You don’t have or don’t want to create a value.
- You want cleaner, safer, and allocation-free code.

Use `reflect.TypeOf` when:
- You already have a value and want its type at runtime.