### PR TITLE
fix: pass standalone prop to ReviewerSelect to prevent usergroup API calls

### DIFF
--- a/web/src/components/ReviewerSelect/ReviewerSelect.tsx
+++ b/web/src/components/ReviewerSelect/ReviewerSelect.tsx
@@ -53,7 +53,12 @@ export interface ReviewerSelectProps extends Omit<ButtonProps, 'onSelect'> {
   standalone?: boolean
 }
 
-export const ReviewerSelect: React.FC<ReviewerSelectProps> = ({ pullRequestMetadata, onSelect, ...props }) => {
+export const ReviewerSelect: React.FC<ReviewerSelectProps> = ({
+  pullRequestMetadata,
+  onSelect,
+  standalone,
+  ...props
+}) => {
   const { getString } = useStrings()
   return (
     <Button
@@ -62,7 +67,13 @@ export const ReviewerSelect: React.FC<ReviewerSelectProps> = ({ pullRequestMetad
       variation={ButtonVariation.TERTIARY}
       minimal
       size={ButtonSize.SMALL}
-      tooltip={<PopoverContent pullRequestMetadata={pullRequestMetadata} onSelect={onSelect} />}
+      tooltip={
+        <PopoverContent
+          pullRequestMetadata={pullRequestMetadata}
+          onSelect={onSelect}
+          standalone={standalone}
+        />
+      }
       tooltipProps={{
         interactionKind: 'click',
         usePortal: true,

--- a/web/src/pages/PullRequest/Conversation/PullRequestSideBar/PullRequestSideBar.tsx
+++ b/web/src/pages/PullRequest/Conversation/PullRequestSideBar/PullRequestSideBar.tsx
@@ -22,6 +22,7 @@ import cx from 'classnames'
 import { Container, Layout, Text, Avatar, FlexExpander, useToaster, Utils, stringSubstitute } from '@harnessio/uicore'
 import { Icon } from '@harnessio/icons'
 import { Color, FontVariation } from '@harnessio/design-system'
+import { useAppContext } from 'AppContext'
 import { OptionsMenuButton } from 'components/OptionsMenuButton/OptionsMenuButton'
 import { useStrings } from 'framework/strings'
 import type {
@@ -56,6 +57,7 @@ interface PullRequestSideBarProps {
 
 const PullRequestSideBar = (props: PullRequestSideBarProps) => {
   const [labelQuery, setLabelQuery] = useState<string>('')
+  const { standalone } = useAppContext()
   const {
     combinedReviewers,
     repoMetadata,
@@ -118,6 +120,7 @@ const PullRequestSideBar = (props: PullRequestSideBarProps) => {
             <FlexExpander />
             <ReviewerSelect
               pullRequestMetadata={pullRequestMetadata}
+              standalone={standalone}
               onSelect={async normalizedPrincipal => {
                 try {
                   const { id, type } = normalizedPrincipal


### PR DESCRIPTION
<img width="718" height="463" alt="image" src="https://github.com/user-attachments/assets/6c93617c-7b60-4137-a2da-b7d6798f2ba8" />
