### PR TITLE
chore: fix incorrect comment for ParseGitspaceOwner function

### DIFF
--- a/types/enum/gitspace.go
+++ b/types/enum/gitspace.go
@@ -65,7 +65,7 @@ const (
 
 func (GitspaceOwner) Enum() []any { return toInterfaceSlice(GitspaceOwners) }
 
-// ParseGitspaceSort parses the gitspace sort attribute string
+// ParseGitspaceOwner parses the gitspace owner attribute string
 // and returns the equivalent enumeration.
 func ParseGitspaceOwner(s string) GitspaceOwner {
 	switch strings.ToLower(s) {


### PR DESCRIPTION
The comment for the ParseGitspaceOwner function was incorrectly copied from ParseGitspaceSort function. This change corrects the comment to accurately reflect that the function parses gitspace owner attribute strings rather than sort attributes.


(I discovered this issue through AI and manually verified and fixed it.)