### PR TITLE
chore: fix incorrect function names

### DIFF
--- a/pubsub/options.go
+++ b/pubsub/options.go
@@ -100,7 +100,7 @@ func WithTopics(topics ...string) SubscribeOption {
 	})
 }
 
-// WithNamespace returns an channel option that configures namespace.
+// WithChannelNamespace returns an channel option that configures namespace.
 func WithChannelNamespace(value string) SubscribeOption {
 	return SubscribeOptionFunc(func(c *SubscribeConfig) {
 		c.namespace = value

--- a/registry/app/storage/filereader.go
+++ b/registry/app/storage/filereader.go
@@ -148,7 +148,7 @@ func (fr *FileReader) reader() (io.Reader, error) {
 	return fr.brd, nil
 }
 
-// resetReader resets the reader, forcing the read method to open up a new
+// reset resets the reader, forcing the read method to open up a new
 // connection and rebuild the buffered reader. This should be called when the
 // offset and the reader will become out of sync, such as during a seek
 // operation.


### PR DESCRIPTION
fix incorrect function names