### PR TITLE
fix: handle wildcard CODEOWNERS file matches

### DIFF
--- a/app/services/codeowners/service.go
+++ b/app/services/codeowners/service.go
@@ -628,12 +628,6 @@ func findReviewerInList(email string, uid string, reviewers []*types.PullReqRevi
 // Match matches a file path against the provided CODEOWNERS pattern.
 // The code follows the .gitignore syntax closely (similar to github):
 // https://git-scm.com/docs/gitignore#_pattern_format
-//
-// IMPORTANT: It seems that doublestar has a bug, as `*k/**` matches `k` but `k*/**` doesnt (incorrect)'.
-// Because of that, we currently match patterns like `test*` only partially:
-// - `test2`, `test/abc`, `test2/abc` are matching
-// - `test` is not matching
-// As a workaround, the user will have to add the same rule without a trailing `*` for now.
 func match(pattern string, path string) (bool, error) {
 	if pattern == "" {
 		return false, fmt.Errorf("empty pattern not allowed")
@@ -667,6 +661,14 @@ func match(pattern string, path string) (bool, error) {
 	// Since doublestar matches pattern "x/**" with target "x", we replace it with "x/*/**".
 	if strings.HasSuffix(pattern, "/**") {
 		pattern = pattern[:len(pattern)-3] + "/*/**"
+	}
+
+	fileMatch, err := doublestar.PathMatch(pattern, path)
+	if err != nil {
+		return false, fmt.Errorf("failed doublestar path match: %w", err)
+	}
+	if fileMatch {
+		return true, nil
 	}
 
 	// If CODEOWNERS matches a file, it also matches a folder with the same name, and anything inside that folder.

--- a/app/services/codeowners/service_test.go
+++ b/app/services/codeowners/service_test.go
@@ -406,17 +406,14 @@ func Test_match(t *testing.T) {
 				nonMatchingTargets: []string{"a.txt"},
 			},
 		},
-		/*
-			TODO: Fix bug in doublestar library, currently doesn't match `a.` ...
-				{
-					name: "trailing match-all on string",
-					args: args{
-						pattern:            "a.*",
-						matchingTargets:    []string{"a.", "a.txt", "x/a.txt", "x/a.txt/b.go", "x/a.txt/b.go/c.ar"},
-						nonMatchingTargets: []string{"atxt", "b.txt"},
-					},
-				},
-		*/
+		{
+			name: "trailing match-all on string",
+			args: args{
+				pattern:            "a.*",
+				matchingTargets:    []string{"a.", "a.txt", "x/a.txt", "x/a.txt/b.go", "x/a.txt/b.go/c.ar"},
+				nonMatchingTargets: []string{"atxt", "b.txt"},
+			},
+		},
 		{
 			name: "globstar",
 			args: args{
@@ -441,17 +438,14 @@ func Test_match(t *testing.T) {
 				nonMatchingTargets: []string{"a.txt", "x", "y/a.txt", "w/x/a.txt"},
 			},
 		},
-		/*
-			TODO: Fix bug in doublestar library, currently doesn't match `a.` ...
-				{
-					name: "trailing globstar on string",
-					args: args{
-						pattern:            "a.**",
-						matchingTargets:    []string{"a.", "a.txt", "x/a.txt", "x/a.txt/b.go", "x/a.txt/b.go/c.ar"},
-						nonMatchingTargets: []string{"atxt", "b.txt"},
-					},
-				},
-		*/
+		{
+			name: "trailing globstar on string",
+			args: args{
+				pattern:            "a.**",
+				matchingTargets:    []string{"a.", "a.txt", "x/a.txt", "x/a.txt/b.go", "x/a.txt/b.go/c.ar"},
+				nonMatchingTargets: []string{"atxt", "b.txt"},
+			},
+		},
 		{
 			name: "leading globstar",
 			args: args{


### PR DESCRIPTION
Small CODEOWNERS matcher fix.

Patterns like `a.*` and `a.**` should match the file `a.` too. Before this, the matcher only hit the child-path form, so `a.` slipped through. tiny papercut, but kinda confusing ngl.

Repro before the fix:

```text
match("a.*", "a.") = false but wanted true
match("a.**", "a.") = false but wanted true
```

Fix is to check the normalized file pattern first, then fall through to the existing descendant match logic.

Verified with:

```bash
go test ./app/services/codeowners -count=1
```

I looked for related CODEOWNERS/doublestar issues and PRs, didn't find a matching one.