### PR TITLE
fix(code): accept executable CODEOWNERS blobs during merge (CODE-5473)

### DIFF
--- a/app/api/usererror/translate.go
+++ b/app/api/usererror/translate.go
@@ -40,9 +40,10 @@ func Translate(ctx context.Context, err error) *Error {
 		appError                 *errors.Error
 		unrelatedHistoriesErr    *api.UnrelatedHistoriesError
 		maxBytesErr              *http.MaxBytesError
-		codeOwnersTooLargeError  *codeowners.TooLargeError
-		codeOwnersFileParseError *codeowners.FileParseError
-		lockError                *lock.Error
+		codeOwnersTooLargeError      *codeowners.TooLargeError
+		codeOwnersFileParseError     *codeowners.FileParseError
+		codeOwnersInvalidFileModeErr *codeowners.InvalidFileModeError
+		lockError                    *lock.Error
 	)
 
 	// print original error for debugging purposes
@@ -136,6 +137,8 @@ func Translate(ctx context.Context, err error) *Error {
 				"err":         codeOwnersFileParseError.Err.Error(),
 			},
 		)
+	case errors.As(err, &codeOwnersInvalidFileModeErr):
+		return UnprocessableEntity(codeOwnersInvalidFileModeErr.Error())
 	// lock errors
 	case errors.As(err, &lockError):
 		return errorFromLockError(lockError)

--- a/app/services/codeowners/service.go
+++ b/app/services/codeowners/service.go
@@ -103,6 +103,36 @@ func (e *FileParseError) Is(target error) bool {
 	return ok
 }
 
+// InvalidFileModeError is returned when CODEOWNERS exists but is not a readable blob
+// (e.g. directory, symlink, or submodule).
+type InvalidFileModeError struct {
+	Mode git.TreeNodeMode
+}
+
+func (e *InvalidFileModeError) Error() string {
+	return fmt.Sprintf(
+		"The repository's CODEOWNERS file has an unsupported type (%s). CODEOWNERS must be a regular file.",
+		e.Mode,
+	)
+}
+
+//nolint:errorlint // the purpose of this method is to check whether the target itself if of this type.
+func (e *InvalidFileModeError) Is(target error) bool {
+	_, ok := target.(*InvalidFileModeError)
+	return ok
+}
+
+// validateCodeOwnersFileMode ensures the tree node is a blob we can read as text.
+// Executable blobs (100755) are accepted to match repo content handling and GitHub behavior.
+func validateCodeOwnersFileMode(mode git.TreeNodeMode) error {
+	switch mode {
+	case git.TreeNodeModeFile, git.TreeNodeModeExec:
+		return nil
+	default:
+		return &InvalidFileModeError{Mode: mode}
+	}
+}
+
 type Config struct {
 	FilePaths []string
 }
@@ -295,12 +325,8 @@ func (s *Service) getCodeOwnerFile(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get CODEOWNERS file node: %w", err)
 	}
-	if node.Node.Mode != git.TreeNodeModeFile {
-		return nil, fmt.Errorf(
-			"CODEOWNERS file is of format '%s' but expected to be of format '%s'",
-			node.Node.Mode,
-			git.TreeNodeModeFile,
-		)
+	if err := validateCodeOwnersFileMode(node.Node.Mode); err != nil {
+		return nil, err
 	}
 
 	output, err := s.git.GetBlob(ctx, &git.GetBlobParams{

--- a/app/services/codeowners/service_test.go
+++ b/app/services/codeowners/service_test.go
@@ -15,12 +15,43 @@
 package codeowners
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/harness/gitness/app/store"
 	"github.com/harness/gitness/git"
 )
+
+func Test_validateCodeOwnersFileMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    git.TreeNodeMode
+		wantErr bool
+	}{
+		{name: "regular file", mode: git.TreeNodeModeFile, wantErr: false},
+		{name: "executable file", mode: git.TreeNodeModeExec, wantErr: false},
+		{name: "directory", mode: git.TreeNodeModeTree, wantErr: true},
+		{name: "symlink", mode: git.TreeNodeModeSymlink, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCodeOwnersFileMode(tt.mode)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateCodeOwnersFileMode(%v) error = %v, wantErr %v", tt.mode, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				var modeErr *InvalidFileModeError
+				if !errors.As(err, &modeErr) {
+					t.Fatalf("expected InvalidFileModeError, got %T: %v", err, err)
+				}
+				if modeErr.Mode != tt.mode {
+					t.Fatalf("mode = %v, want %v", modeErr.Mode, tt.mode)
+				}
+			}
+		})
+	}
+}
 
 func TestService_ParseCodeOwner(t *testing.T) {
 	type fields struct {


### PR DESCRIPTION
Merge protection failed with HTTP 500 when CODEOWNERS was stored as a Git executable blob (mode 100755). Treat exec blobs like regular files, consistent with repo content APIs, and map unsupported node types to 422.