### PR TITLE
fix(paths): IsAncesterOf must match full path segments

### DIFF
--- a/app/paths/paths.go
+++ b/app/paths/paths.go
@@ -128,8 +128,16 @@ func IsAncesterOf(path string, other string) bool {
 	path = strings.Trim(path, types.PathSeparatorAsString)
 	other = strings.Trim(other, types.PathSeparatorAsString)
 
-	// add "/" to both to handle space1/inner and space1/in
-	return strings.Contains(
+	// the root space (empty path) is an ancestor of everything.
+	if path == "" {
+		return true
+	}
+
+	// append the separator to both sides so that an ancestor relation requires a
+	// full leading segment match: this rejects prefixes that aren't segment
+	// boundaries (space1 vs space10, space1/in vs space1/inner) as well as paths
+	// that merely appear as a trailing segment of other (space2 vs space1/space2).
+	return strings.HasPrefix(
 		other+types.PathSeparatorAsString,
 		path+types.PathSeparatorAsString,
 	)

--- a/app/paths/paths_test.go
+++ b/app/paths/paths_test.go
@@ -414,6 +414,24 @@ func Test_IsAncesterOf(t *testing.T) {
 			other: "space1/inner",
 			want:  false,
 		},
+		// A path that is only a trailing segment of other is NOT an ancestor of it.
+		// IsAncesterOf guards an authorization scope in app/auth/authz/membership.go,
+		// so a false positive here would escape that scope.
+		{
+			path:  "space2",
+			other: "space1/space2",
+			want:  false,
+		},
+		{
+			path:  "a",
+			other: "b/a",
+			want:  false,
+		},
+		{
+			path:  "b/c",
+			other: "a/b/c",
+			want:  false,
+		},
 	}
 	for _, tt := range tests {
 		got := IsAncesterOf(tt.path, tt.other)


### PR DESCRIPTION
### What
`IsAncesterOf` is documented to return true iff `path` is an ancestor of `other` (or they are equal), but `strings.Contains` also matches when `path` is only a trailing segment of `other`:

```go
IsAncesterOf("space2", "space1/space2") // was true, now false
```

Fixes #3699.

### Why it matters
`IsAncesterOf` guards an authorization scope in `app/auth/authz/membership.go` (`checkWithMembershipMetadata`). A false positive lets a request fall outside the ephemeral membership scope when a space name collides with the trailing segment of another space path. Impact is modest: the `SpaceID` driving `space.Path` comes from a server-signed membership token (not user-forgeable), so exploitation requires a space-naming collision — but the helper should still honor its documented contract.

### Change
- Use `strings.HasPrefix` on the separator-terminated paths so an ancestor relation requires a full leading-segment match. The empty/root path is kept as an ancestor of everything, preserving prior behaviour.
- Add the missing trailing-segment negative cases to `Test_IsAncesterOf`.

### Validation
- `go test ./app/paths/` — full suite green. The new cases fail on the previous `strings.Contains` implementation (verified by reverting the fix), so they actually guard the change.
- `go vet ./app/paths/` clean.

### Note
Analysis and patch were produced with AI assistance; every line was reviewed and validated by me. The repo has no AI policy — including this for transparency.
