### PR TITLE
docs(registry): fix stale file listing in maven conformance README

### DIFF
--- a/registry/tests/maven/README.md
+++ b/registry/tests/maven/README.md
@@ -156,8 +156,9 @@ registry/tests/maven/
 ├── 03_content_discovery_test.go # Content discovery tests
 ├── 05_error_test.go             # Error handling tests
 ├── config.go                    # Test configuration and helpers
-├── client.go                    # HTTP client implementation
 ├── reporter.go                  # Test reporting functionality
+├── reporter_init.go             # Test reporting initialization
+├── generate_junit_report.sh     # JUnit XML report generator script
 └── scripts/                     # Helper scripts
     └── setup_test.sh            # Environment setup script
 ```


### PR DESCRIPTION
## What

The "Directory Structure" section of `registry/tests/maven/README.md` listed `client.go` as one of the files in the test directory, but that file does not exist. The listing was also missing two files that do exist (`reporter_init.go` and `generate_junit_report.sh`).

## Why

A reader following the README would look for `client.go` and not find it. The HTTP client behavior the README attributes to `client.go` is spread across the individual test files. Syncing the listing with the actual directory contents keeps the doc accurate.

## Change

In the `Directory Structure` tree:

- Removed the `client.go` line (file does not exist in `registry/tests/maven/`).
- Added `reporter_init.go` (exists).
- Added `generate_junit_report.sh` (exists, already referenced elsewhere in the README under "JUnit XML Reports").

Every file in the updated listing was verified to exist:

```
00_conformance_suite_test.go  OK
01_download_test.go           OK
02_upload_test.go             OK
03_content_discovery_test.go  OK
05_error_test.go              OK
config.go                     OK
reporter.go                   OK
reporter_init.go              OK
generate_junit_report.sh      OK
scripts/setup_test.sh         OK
```

Docs-only change, no code or behavior affected.
