### PR TITLE
fix(webhook): filter empty tokens and trim space during trigger string parsing

### DIFF
--- a/app/store/database/webhook.go
+++ b/app/store/database/webhook.go
@@ -573,7 +573,7 @@ func triggersFromString(triggersString string) []enum.WebhookTrigger {
 	}
 
 	rawTriggers := strings.Split(triggersString, triggersSeparator)
-	var triggers []enum.WebhookTrigger
+	triggers := make([]enum.WebhookTrigger, 0, len(rawTriggers))
 
 	for _, rawTrigger := range rawTriggers {
 		rawTrigger = strings.TrimSpace(rawTrigger)

--- a/app/store/database/webhook.go
+++ b/app/store/database/webhook.go
@@ -573,11 +573,15 @@ func triggersFromString(triggersString string) []enum.WebhookTrigger {
 	}
 
 	rawTriggers := strings.Split(triggersString, triggersSeparator)
+	var triggers []enum.WebhookTrigger
 
-	triggers := make([]enum.WebhookTrigger, len(rawTriggers))
-	for i, rawTrigger := range rawTriggers {
+	for _, rawTrigger := range rawTriggers {
+		rawTrigger = strings.TrimSpace(rawTrigger)
+		if rawTrigger == "" {
+			continue
+		}
 		// ASSUMPTION: trigger is valid value (as we wrote it to DB)
-		triggers[i] = enum.WebhookTrigger(rawTrigger)
+		triggers = append(triggers, enum.WebhookTrigger(rawTrigger))
 	}
 
 	return triggers

--- a/registry/app/store/database/webhook.go
+++ b/registry/app/store/database/webhook.go
@@ -522,7 +522,7 @@ func triggersFromString(triggersString string) []gitnessenum.WebhookTrigger {
 	}
 
 	rawTriggers := strings.Split(triggersString, triggersSeparator)
-	var triggers []gitnessenum.WebhookTrigger
+	triggers := make([]gitnessenum.WebhookTrigger, 0, len(rawTriggers))
 
 	for _, rawTrigger := range rawTriggers {
 		rawTrigger = strings.TrimSpace(rawTrigger)

--- a/registry/app/store/database/webhook.go
+++ b/registry/app/store/database/webhook.go
@@ -522,9 +522,14 @@ func triggersFromString(triggersString string) []gitnessenum.WebhookTrigger {
 	}
 
 	rawTriggers := strings.Split(triggersString, triggersSeparator)
-	triggers := make([]gitnessenum.WebhookTrigger, len(rawTriggers))
-	for i, rawTrigger := range rawTriggers {
-		triggers[i] = gitnessenum.WebhookTrigger(rawTrigger)
+	var triggers []gitnessenum.WebhookTrigger
+
+	for _, rawTrigger := range rawTriggers {
+		rawTrigger = strings.TrimSpace(rawTrigger)
+		if rawTrigger == "" {
+			continue
+		}
+		triggers = append(triggers, gitnessenum.WebhookTrigger(rawTrigger))
 	}
 
 	return triggers


### PR DESCRIPTION
### Description
This PR addresses an un-sanitized string-splitting vulnerability within the webhook trigger configuration parsing layers. By replacing the fixed-length pre-allocated array indexing mechanism with a dynamic slice appending strategy, we ensure the backend safely drops malformed or empty token segments before they propagate downstream.

### Technical Context
When parsing webhook triggers from standard, comma-delimited string payloads via `strings.Split(triggersString, ",")`, consecutive delimiters (e.g., `push,,pull`) or strings containing trailing whitespaces generate empty or dirty text fragments. 

The previous iteration map loops assigned keys directly using fixed-slice positions (`triggers[i] = ...`), introducing un-guarded empty strings into the strong enum evaluation functions. This layout risks triggering out-of-bounds pointer panics or unexpected map lookup failures during core platform operations.

### Resolution Strategy
* **Dynamic Validation Append:** Refactored the string processing logic across both core and registry persistence handlers (`app/store/database/webhook.go` and `registry/app/store/database/webhook.go`) to utilize a dynamic append slice.
* **String Space Trimming:** Embedded an explicit `strings.TrimSpace` pass on all extracted trigger keys to sanitize raw human entries.
* **Early-Exit Guard:** Added an inline conditional check (`if rawTrigger == "" { continue }`) to completely filter out hollow token slots before casting arrays to enum structures.