### PR TITLE
fix: correctly list pull request branch candidates

### DIFF
--- a/app/api/controller/pullreq/pr_branch_candidates.go
+++ b/app/api/controller/pullreq/pr_branch_candidates.go
@@ -44,25 +44,25 @@ func (c *Controller) PRBranchCandidates(
 
 	cutOffTime := time.Now().Add(-PRBannerDuration)
 
-	// getting latest sha from db instead of git as pr candidate need not be 100% accurate
-	defaultBranch, err := c.branchStore.Find(ctx, repo.ID, repo.DefaultBranch)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default branch: %w", err)
-	}
-
-	branches, err := c.branchStore.FindBranchesWithoutOpenPRs(ctx, repo.ID,
-		session.Principal.ID, cutOffTime.UnixMilli(), limit+1, defaultBranch.SHA.String())
+	branches, err := c.branchStore.FindBranchesWithoutOpenPRs(
+		ctx,
+		repo.ID,
+		session.Principal.ID,
+		cutOffTime.UnixMilli(),
+		limit+1,
+		repo.DefaultBranch,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list branches: %w", err)
 	}
 
-	// Filter out default branch if present
+	// Defensive filtering in case the store returns the default branch.
 	result := make([]types.BranchTable, 0, len(branches))
 	for _, branch := range branches {
 		if branch.Name != repo.DefaultBranch {
 			result = append(result, branch)
 		}
-		// Stop once we've reached the limit
+
 		if uint64(len(result)) >= limit {
 			break
 		}

--- a/app/store/database.go
+++ b/app/store/database.go
@@ -1628,7 +1628,7 @@ type (
 			principalID int64,
 			cutOffTime int64,
 			limit uint64,
-			sha string,
+			defaultBranch string,
 		) ([]types.BranchTable, error)
 
 		// Find finds a branch by repo ID and branch name.

--- a/app/store/database/branch.go
+++ b/app/store/database/branch.go
@@ -95,34 +95,38 @@ func mapInternalBranch(b *types.BranchTable, repoID int64) branch {
 	}
 }
 
-// FindBranchesWithoutOpenPRs finds branches without open pull requests for a repository,
-// or with closed pull requests whose SHA doesn't match the provided SHA.
+// FindBranchesWithoutOpenPRs finds recently updated non-default branches
+// that do not have an open pull request and have not already had a pull
+// request created for their current SHA.
 func (s *branchStore) FindBranchesWithoutOpenPRs(
 	ctx context.Context,
 	repoID int64,
 	principalID int64,
 	cutOffTime int64,
 	limit uint64,
-	sha string,
+	defaultBranch string,
 ) ([]types.BranchTable, error) {
 	db := dbtx.GetAccessor(ctx, s.db)
 
-	// todo: handle complicated scenario whenever pull request is merged and someone pushes to same branch
-	// it gets complicated as with squash and merge the sha will change in main and pullreq branch causing
-	// isAncestor sha match
 	sqlQuery := branchSelectBase + `
-			LEFT JOIN pullreqs ON 
-				((branch_repo_id = pullreq_source_repo_id 
-				AND branch_name = pullreq_source_branch 
-				AND branch_last_created_pullreq_id!=NULL) OR (branch_last_created_pullreq_id = pullreq_id))
-			WHERE branch_repo_id = $1
-				AND branch_updated_by = $2
-				AND branch_updated > $3
-				AND (pullreq_id IS NULL OR (pullreq_state != 'open' AND pullreq_source_sha != branch_sha))
-				AND branch_sha != $4
-			ORDER BY branch_updated DESC
-			LIMIT $5
-		`
+		WHERE branches.branch_repo_id = $1
+			AND branches.branch_updated_by = $2
+			AND branches.branch_updated > $3
+			AND branches.branch_name != $4
+			AND NOT EXISTS (
+				SELECT 1
+				FROM pullreqs
+				WHERE pullreqs.pullreq_source_repo_id = branches.branch_repo_id
+					AND pullreqs.pullreq_source_branch = branches.branch_name
+					AND (
+						pullreqs.pullreq_state = 'open'
+						OR pullreqs.pullreq_source_sha = branches.branch_sha
+					)
+			)
+		ORDER BY branches.branch_updated DESC
+		LIMIT $5
+	`
+
 	dst := make([]*branch, 0, limit)
 	err := db.SelectContext(
 		ctx,
@@ -131,11 +135,15 @@ func (s *branchStore) FindBranchesWithoutOpenPRs(
 		repoID,
 		principalID,
 		cutOffTime,
-		sha,
+		defaultBranch,
 		limit,
 	)
 	if err != nil {
-		return nil, database.ProcessSQLErrorf(ctx, err, "Failed to find branches without PRs")
+		return nil, database.ProcessSQLErrorf(
+			ctx,
+			err,
+			"Failed to find branches without PRs",
+		)
 	}
 
 	result := make([]types.BranchTable, len(dst))


### PR DESCRIPTION
## Summary

This PR fixes the PR banner candidate selection logic so that:

- Newly created branches correctly appear as PR candidates before any pull request is created.
- Branches with an open pull request are excluded.
- Branches whose latest commit has already been used to create a pull request are excluded.
- The default branch no longer depends on a corresponding row in the `branches` table.

---

## Problem

The existing implementation fetched the default branch metadata from the `branches` table before querying PR banner candidates.

For newly created repositories, the default branch may already exist in Git while its metadata has not yet been persisted in the `branches` table. In that situation, the endpoint:

```text
GET /api/v1/repos/{repo}/+/pullreq/candidates
```

returned **404 (Not Found)**, preventing the UI from displaying the **"Compare & Pull Request"** banner.

Additionally, the previous SQL query relied on joins involving `branch_last_created_pullreq_id`, which could lead to incorrect banner behaviour in certain scenarios.

---

## Root Cause

Candidate lookup depended on:

- Looking up the default branch SHA from the database.
- Joining against the latest recorded pull request.

If the default branch record was missing, candidate lookup failed entirely.

The join-based query also made it difficult to reliably distinguish between:

- branches with an open PR,
- branches whose current commit already has a PR, and
- branches that genuinely require a new PR.

---

## Solution

This PR simplifies the candidate selection logic by:

- Passing the default branch **name** instead of its SHA.
- Excluding the default branch directly in the SQL query.
- Replacing the previous join with a `NOT EXISTS` query that filters branches where:
  - an **open** pull request already exists, or
  - a pull request has already been created for the current branch SHA.

This removes the dependency on the default branch metadata while preserving the intended banner behaviour.

---

## Testing

Verified manually using a fresh database.

### Scenarios Tested

- ✅ New repository
- ✅ First feature branch immediately displays the PR banner
- ✅ Creating a pull request removes the banner
- ✅ Merging or closing the pull request keeps the banner hidden for the same commit
- ✅ Pushing new commits to the branch shows the banner again
- ✅ Multiple repositories
- ✅ Regression test for the original false-banner issue (banner no longer persists after PR creation)

---

## Notes

This change is intentionally scoped to the backend candidate selection logic and does not introduce any UI changes.