### PR TITLE
refactor: use WaitGroup.Go to simplify code

### DIFF
--- a/app/services/usage/usage_test.go
+++ b/app/services/usage/usage_test.go
@@ -120,9 +120,7 @@ func TestMediator_basic(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	for range numBandwidthRoutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_ = mediator.Send(context.Background(), Metric{
 				SpaceRef: space.Identifier,
 				Bandwidth: Bandwidth{
@@ -130,7 +128,7 @@ func TestMediator_basic(t *testing.T) {
 					In:  int64(defaultSize),
 				},
 			})
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/git/diff.go
+++ b/git/diff.go
@@ -372,9 +372,7 @@ func (s *Service) Diff(
 
 	pr, pw := io.Pipe()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer pw.Close()
 
 		if err := params.Validate(); err != nil {
@@ -387,11 +385,9 @@ func (s *Service) Diff(
 			cherr <- err
 			return
 		}
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer pr.Close()
 
 		parser := diff.Parser{
@@ -419,7 +415,7 @@ func (s *Service) Diff(
 			cherr <- err
 			return
 		}
-	}()
+	})
 
 	go func() {
 		wg.Wait()

--- a/lock/memory_test.go
+++ b/lock/memory_test.go
@@ -33,9 +33,7 @@ func Test_inMemMutex_Lock(t *testing.T) {
 		RetryDelay: 300 * time.Millisecond,
 	})
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		time.Sleep(500 * time.Millisecond)
 		mx, err := manager.NewMutex("key1")
 		if err != nil {
@@ -48,7 +46,7 @@ func Test_inMemMutex_Lock(t *testing.T) {
 		}
 		err = mx.Unlock(context.Background())
 		require.NoError(t, err)
-	}()
+	})
 
 	mx, err := manager.NewMutex("key1")
 	if err != nil {
@@ -73,9 +71,7 @@ func Test_inMemMutex_MaxTries(t *testing.T) {
 		RetryDelay: 300 * time.Millisecond,
 	})
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		time.Sleep(500 * time.Millisecond)
 		mx, err := manager.NewMutex("key1")
 		if err != nil {
@@ -97,7 +93,7 @@ func Test_inMemMutex_MaxTries(t *testing.T) {
 			t.Errorf("expected lock.MaxRetriesExceeded, got: %v", err)
 			return
 		}
-	}()
+	})
 
 	mx, err := manager.NewMutex("key1")
 	if err != nil {

--- a/registry/app/driver/base/regulator_test.go
+++ b/registry/app/driver/base/regulator_test.go
@@ -55,13 +55,11 @@ func TestRegulatorEnterExit(t *testing.T) {
 		var secondGroupDone sync.WaitGroup
 		for range 50 {
 			secondGroupReady.Add(1)
-			secondGroupDone.Add(1)
-			go func() {
+			secondGroupDone.Go(func() {
 				secondGroupReady.Done()
 				r.enter()
 				r.exit()
-				secondGroupDone.Done()
-			}()
+			})
 		}
 		secondGroupReady.Wait()
 

--- a/stream/memory_consumer.go
+++ b/stream/memory_consumer.go
@@ -135,11 +135,9 @@ func (c *MemoryConsumer) Start(ctx context.Context) error {
 
 	// start workers
 	for i := 0; i < c.Config.Concurrency; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			c.consume(ctx)
-		}()
+		})
 	}
 
 	// start cleanup routing

--- a/stream/redis_consumer.go
+++ b/stream/redis_consumer.go
@@ -148,32 +148,26 @@ func (c *RedisConsumer) Start(ctx context.Context) error {
 
 	wg := &sync.WaitGroup{}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		c.removeStaleConsumers(ctx, time.Hour)
 		// launch redis reader, it will finish when the ctx is done
 		c.reader(ctx)
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		// launch redis message reclaimer, it will finish when the ctx is done.
 		// IMPORTANT: Keep reclaim interval small for now to support faster retries => higher load on redis!
 		// TODO: Make retries local by default with opt-in cross-instance retries.
 		// https://harness.atlassian.net/browse/SCM-83
 		const reclaimInterval = 10 * time.Second
 		c.reclaimer(ctx, reclaimInterval)
-	}()
+	})
 
 	for i := 0; i < c.Config.Concurrency; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// launch redis message consumer, it will finish when the ctx is done
 			c.consumer(ctx)
-		}()
+		})
 	}
 
 	go func() {


### PR DESCRIPTION
Use sync.WaitGroup.Go (Go 1.25) to replace the manual Add/Done pattern, reducing boilerplate and eliminating mismatched counter bugs. 

More info can see: https://github.com/golang/go/issues/63796