### PR TITLE
fix: enforce push protection for plain API content writes

### DIFF
--- a/app/api/controller/githook/pre_receive.go
+++ b/app/api/controller/githook/pre_receive.go
@@ -287,12 +287,9 @@ func (c *Controller) checkPushProtection(
 ) ([]types.RuleViolations, *repoSettingsViolations, error) {
 	pushProtection := c.protectionManager.FilterPushProtection(protectionRules)
 
-	// TODO: Once push rule violations are returned to the API layer,
-	// allow bypass only for operations that explicitly support it.
-	// Specifically:
-	//   - GitOpTypeAPIContentBypassRules: API operations that intentionally bypass rules
-	//   - GitOpTypeGitPush: direct git pushes from clients
-	allowBypass := true
+	// Only direct git pushes and API operations that explicitly request bypass
+	// semantics may bypass push protection rules.
+	allowBypass := allowPushProtectionBypass(in.OperationType)
 
 	pushVerifyOut, _, err := pushProtection.PushVerify(
 		ctx,
@@ -366,6 +363,15 @@ func (c *Controller) checkPushProtection(
 	}
 
 	return rulesViolations, &settingsViolations, nil
+}
+
+func allowPushProtectionBypass(opType enum.GitOpType) bool {
+	switch opType {
+	case enum.GitOpTypeGitPush, enum.GitOpTypeAPIContentBypassRules:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *Controller) blockPullReqRefUpdate(refUpdates changedRefs, state enum.RepoState) bool {

--- a/app/api/controller/githook/pre_receive_test.go
+++ b/app/api/controller/githook/pre_receive_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Harness, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githook
+
+import (
+	"testing"
+
+	"github.com/harness/gitness/types/enum"
+)
+
+func TestCheckPushProtection_DoesNotBypassForPlainAPIContent(t *testing.T) {
+	t.Parallel()
+
+	if allowPushProtectionBypass(enum.GitOpTypeAPIContent) {
+		t.Fatal("plain API content must not bypass push protection")
+	}
+}
+
+func TestCheckPushProtection_DoesBypassForAPIContentBypassRules(t *testing.T) {
+	t.Parallel()
+
+	if !allowPushProtectionBypass(enum.GitOpTypeAPIContentBypassRules) {
+		t.Fatal("API content with an explicit bypass request must bypass push protection")
+	}
+}
+
+func TestAllowPushProtectionBypass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		opType     enum.GitOpType
+		wantBypass bool
+	}{
+		{name: "git push", opType: enum.GitOpTypeGitPush, wantBypass: true},
+		{name: "refs only", opType: enum.GitOpTypeAPIRefsOnly, wantBypass: false},
+		{name: "system refs", opType: enum.GitOpTypeAPISystemRefs, wantBypass: false},
+		{name: "linked sync", opType: enum.GitOpTypeAPILinkedSync, wantBypass: false},
+		{name: "plain API content", opType: enum.GitOpTypeAPIContent, wantBypass: false},
+		{name: "explicit API bypass", opType: enum.GitOpTypeAPIContentBypassRules, wantBypass: true},
+		{name: "repository management", opType: enum.GitOpTypeManageRepo, wantBypass: false},
+		{name: "merge queue", opType: enum.GitOpTypeMergeQueue, wantBypass: false},
+		{name: "unknown operation", opType: enum.GitOpType("unknown"), wantBypass: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := allowPushProtectionBypass(tt.opType); got != tt.wantBypass {
+				t.Fatalf("allowPushProtectionBypass(%q) = %t, want %t", tt.opType, got, tt.wantBypass)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3681

## Summary

- restrict push-protection bypass to direct Git pushes and API content operations that explicitly request bypass semantics
- keep plain API content writes subject to push-protection rules
- add regression coverage for plain API content, explicit API bypass, direct Git pushes, and other operation types

## Root cause

checkPushProtection passed AllowBypass: true for every pre-receive operation, so plain API content writes were treated like explicit bypass operations.

## Validation

- go test ./app/api/controller/githook (pass)
- go test ./app/services/protection (pass)
- make test (pass; excludes the repository’s documented registry conformance packages)
- git diff --check (pass)

The frontend dependencies were installed and yarn build completed successfully to provide the embedded web/dist assets required by the full Go test target.
