### PR TITLE
fix: authorize InfraProvider reads

### DIFF
--- a/app/api/controller/infraprovider/find.go
+++ b/app/api/controller/infraprovider/find.go
@@ -18,13 +18,15 @@ import (
 	"context"
 	"fmt"
 
+	apiauth "github.com/harness/gitness/app/api/auth"
 	"github.com/harness/gitness/app/auth"
 	"github.com/harness/gitness/types"
+	"github.com/harness/gitness/types/enum"
 )
 
 func (c *Controller) Find(
 	ctx context.Context,
-	_ *auth.Session,
+	session *auth.Session,
 	spaceRef string,
 	identifier string,
 ) (*types.InfraProviderConfig, error) {
@@ -32,10 +34,9 @@ func (c *Controller) Find(
 	if err != nil {
 		return nil, fmt.Errorf("failed to find space: %w", err)
 	}
-	// todo: add acl check with PermissionInfraProviderView once infra provider resource is added to access control
-	// err = apiauth.CheckGitspace(ctx, c.authorizer, session, space.Path, identifier, enum.PermissionGitspaceView)
-	// if err != nil {
-	//	return nil, fmt.Errorf("failed to authorize: %w", err)
-	// }
+	err = apiauth.CheckInfraProvider(ctx, c.authorizer, session, space.Path, identifier, enum.PermissionInfraProviderView)
+	if err != nil {
+		return nil, fmt.Errorf("failed to authorize: %w", err)
+	}
 	return c.infraproviderSvc.Find(ctx, space, identifier)
 }

--- a/app/api/controller/infraprovider/find_test.go
+++ b/app/api/controller/infraprovider/find_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Harness, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	apiauth "github.com/harness/gitness/app/api/auth"
+	"github.com/harness/gitness/app/auth"
+	"github.com/harness/gitness/app/auth/authz/authztest"
+	serviceinfraprovider "github.com/harness/gitness/app/services/infraprovider"
+	"github.com/harness/gitness/app/services/refcache"
+	storecache "github.com/harness/gitness/app/store/cache"
+	"github.com/harness/gitness/types"
+	"github.com/harness/gitness/types/enum"
+)
+
+type staticSpaceIDCache struct {
+	spaces map[int64]*types.SpaceCore
+}
+
+func (c *staticSpaceIDCache) Stats() (int64, int64)            { return 0, 0 }
+func (c *staticSpaceIDCache) Evict(_ context.Context, _ int64) {}
+func (c *staticSpaceIDCache) Get(_ context.Context, id int64) (*types.SpaceCore, error) {
+	if space, ok := c.spaces[id]; ok {
+		return space, nil
+	}
+	return nil, fmt.Errorf("space %d not found", id)
+}
+
+type recordingInfraProviderConfigStore struct {
+	findByIdentifierCalls int
+}
+
+func (s *recordingInfraProviderConfigStore) Find(
+	context.Context, int64, bool,
+) (*types.InfraProviderConfig, error) {
+	return nil, errors.New("unexpected config store call")
+}
+
+func (s *recordingInfraProviderConfigStore) FindByType(
+	context.Context, int64, enum.InfraProviderType, bool,
+) (*types.InfraProviderConfig, error) {
+	return nil, errors.New("unexpected config store call")
+}
+
+func (s *recordingInfraProviderConfigStore) FindByIdentifier(
+	context.Context, int64, string,
+) (*types.InfraProviderConfig, error) {
+	s.findByIdentifierCalls++
+	return nil, errors.New("unexpected config store call")
+}
+
+func (s *recordingInfraProviderConfigStore) List(
+	context.Context, *types.InfraProviderConfigFilter,
+) ([]*types.InfraProviderConfig, error) {
+	return nil, errors.New("unexpected config store call")
+}
+
+func (s *recordingInfraProviderConfigStore) Create(context.Context, *types.InfraProviderConfig) error {
+	return errors.New("unexpected config store call")
+}
+
+func (s *recordingInfraProviderConfigStore) Update(context.Context, *types.InfraProviderConfig) error {
+	return errors.New("unexpected config store call")
+}
+
+func (s *recordingInfraProviderConfigStore) Delete(context.Context, int64) error {
+	return errors.New("unexpected config store call")
+}
+
+func TestFindRequiresInfraProviderViewPermission(t *testing.T) {
+	configStore := &recordingInfraProviderConfigStore{}
+	spaceFinder := refcache.NewSpaceFinder(
+		&staticSpaceIDCache{
+			spaces: map[int64]*types.SpaceCore{
+				1: {ID: 1, Path: "acme/platform"},
+			},
+		},
+		nil,
+		nil,
+		storecache.Evictor[*types.SpaceCore]{},
+	)
+	infraProviderService := serviceinfraprovider.NewService(
+		nil,
+		nil,
+		nil,
+		configStore,
+		nil,
+		nil,
+		spaceFinder,
+		nil,
+	)
+	controller := NewController(authztest.DenyAuthorizer{}, spaceFinder, infraProviderService)
+
+	session := &auth.Session{Principal: types.Principal{UID: "user"}}
+	_, err := controller.Find(context.Background(), session, "1", "docker")
+	if !errors.Is(err, apiauth.ErrForbidden) {
+		t.Fatalf("Find() error = %v, want forbidden", err)
+	}
+	if configStore.findByIdentifierCalls != 0 {
+		t.Fatalf("config store was called %d times after authorization failed", configStore.findByIdentifierCalls)
+	}
+}


### PR DESCRIPTION
Fixes #3697 by enforcing PermissionInfraProviderView before returning an InfraProvider configuration from the Find controller.

The regression test verifies that a denied authenticated session receives a forbidden error and that the config store is not queried.

Tests:
- go test ./app/api/controller/infraprovider -count=1
- go vet ./app/api/controller/infraprovider