### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ $ ./gitness user pat "my-pat-uid" 2592000
 ```
 
 The command outputs a valid PAT that has been granted full access as the user.
-The token can then be send as part of the `Authorization` header with Postman or curl:
+The token can then be sent as part of the `Authorization` header with Postman or curl:
 
 ```bash
 $ curl http://localhost:3000/api/v1/user \

--- a/scripts/license/README.md
+++ b/scripts/license/README.md
@@ -1,4 +1,4 @@
-# Backfil license headers
+# Backfill license headers
 The script in this folder can be used to backfill license headers on existing files.
 To run the script, execute:
 ```bash


### PR DESCRIPTION
## What changed

Fixed two typos in documentation:

- `scripts/license/README.md`: `Backfil` → `Backfill` (the next line already spells "backfill" correctly)
- `README.md`: `The token can then be send` → `be sent`

## How verified

Diff inspection — documentation only, no code changes.