### PR TITLE
docs: fix 7 typos in Go comments

### DIFF
--- a/app/api/controller/space/controller.go
+++ b/app/api/controller/space/controller.go
@@ -192,7 +192,7 @@ func (c *Controller) getSpaceCheckAuthSpaceCreation(
 ) (*types.SpaceCore, error) {
 	parentRefAsID, err := strconv.ParseInt(parentRef, 10, 64)
 	if (parentRefAsID <= 0 && err == nil) || (len(strings.TrimSpace(parentRef)) == 0) {
-		// TODO: Restrict top level space creation - should be move to authorizer?
+		// TODO: Restrict top level space creation - should be moved to authorizer?
 		if auth.IsAnonymousSession(session) {
 			return nil, fmt.Errorf("anonymous user not allowed to create top level spaces: %w", usererror.ErrUnauthorized)
 		}

--- a/app/gitspace/orchestrator/container/devcontainer_config_utils.go
+++ b/app/gitspace/orchestrator/container/devcontainer_config_utils.go
@@ -174,7 +174,7 @@ func ExtractEnv(devcontainerConfig types.DevcontainerConfig, runArgsMap map[type
 func ExtractForwardPorts(devcontainerConfig types.DevcontainerConfig) []int {
 	var ports []int
 	for _, strPort := range devcontainerConfig.ForwardPorts {
-		portAsInt, err := strPort.Int64() // Using Atoi to convert string to int
+		portAsInt, err := strPort.Int64() // Using Int64 to convert string to int
 		if err != nil {
 			log.Warn().Msgf("Error converting port string '%s' to int: %v", strPort, err)
 			continue // Skip the invalid port
@@ -225,7 +225,7 @@ func AddIDEDownloadURLArg(
 	args map[gitspaceTypes.IDEArg]any,
 ) map[gitspaceTypes.IDEArg]any {
 	if !enum.IsJetBrainsIDE(ideService.Type()) {
-		// currently download url is only need for jetbrains IDEs
+		// currently download url is only needed for jetbrains IDEs
 		return args
 	}
 
@@ -246,7 +246,7 @@ func AddIDEDirNameArg(
 	args map[gitspaceTypes.IDEArg]any,
 ) map[gitspaceTypes.IDEArg]any {
 	if !enum.IsJetBrainsIDE(ideService.Type()) {
-		// currently dirname is only need for jetbrains IDEs
+		// currently dirname is only needed for jetbrains IDEs
 		return args
 	}
 

--- a/registry/app/storage/ociblobstore.go
+++ b/registry/app/storage/ociblobstore.go
@@ -224,9 +224,9 @@ func (bs *ociBlobStore) Open(
 }
 
 // Put stores the content p in the blob store, calculating the digest.
-// If thebcontent is already present, only the digest will be returned.
-// This shouldbonly be used for small objects, such as manifests.
-// This implemented as a convenience for other Put implementations.
+// If the content is already present, only the digest will be returned.
+// This should only be used for small objects, such as manifests.
+// This is implemented as a convenience for other Put implementations.
 func (bs *ociBlobStore) Put(
 	ctx context.Context, pathPrefix string,
 	p []byte,


### PR DESCRIPTION
## Summary

Fix 7 typos/grammar issues in Go comments across 3 files:

- **registry/app/storage/ociblobstore.go**: `If thebcontent is already present` -> `If the content is already present`; `This shouldbonly be used` -> `This should only be used`; `This implemented as a convenience` -> `This is implemented as a convenience`
- **app/gitspace/orchestrator/container/devcontainer_config_utils.go**: `// Using Atoi to convert string to int` -> `// Using Int64 to convert string to int` (the code calls `strPort.Int64()`, not `strconv.Atoi`); `only need for jetbrains IDEs` -> `only needed for jetbrains IDEs` (x2)
- **app/api/controller/space/controller.go**: `should be move to authorizer?` -> `should be moved to authorizer?`

No functional changes - comments only. No identifiers were renamed.