### PR TITLE
Improve database query performance for Postgres

### DIFF
--- a/service/repo/repo.go
+++ b/service/repo/repo.go
@@ -16,10 +16,18 @@ package repo
 
 import (
 	"context"
+	"sync"
 
 	"github.com/drone/drone/core"
 	"github.com/drone/go-scm/scm"
+
+	"golang.org/x/sync/errgroup"
 )
+
+// listPageConcurrency bounds how many repository-list pages are
+// fetched from the SCM provider at once, to stay well clear of
+// secondary rate limits (e.g. GitHub's abuse-detection mechanism).
+const listPageConcurrency = 6
 
 type service struct {
 	renew      core.Renewer
@@ -49,24 +57,54 @@ func (s *service) List(ctx context.Context, user *core.User) ([]*core.Repository
 		Token:   user.Token,
 		Refresh: user.Refresh,
 	})
-	repos := []*core.Repository{}
+
 	opts := scm.ListOptions{Size: 100}
-	for {
+	result, meta, err := s.client.Repositories.List(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	repos := convertRepositories(result, s.visibility, s.trusted)
+
+	if meta.Page.Last > 1 {
+		// the provider told us the total page count up front (e.g.
+		// GitHub's Link: rel="last" header, surfaced as meta.Page.Last)
+		// -- fetch the remaining pages concurrently instead of walking
+		// them one at a time. Order doesn't matter to any caller of
+		// List, so pages are appended as they complete.
+		var mu sync.Mutex
+		group, gctx := errgroup.WithContext(ctx)
+		group.SetLimit(listPageConcurrency)
+		for page := 2; page <= meta.Page.Last; page++ {
+			page := page
+			group.Go(func() error {
+				pageOpts := scm.ListOptions{Size: opts.Size, Page: page}
+				result, _, err := s.client.Repositories.List(gctx, pageOpts)
+				if err != nil {
+					return err
+				}
+				converted := convertRepositories(result, s.visibility, s.trusted)
+				mu.Lock()
+				repos = append(repos, converted...)
+				mu.Unlock()
+				return nil
+			})
+		}
+		if err := group.Wait(); err != nil {
+			return nil, err
+		}
+		return repos, nil
+	}
+
+	// the provider only exposes an opaque next-page cursor with no
+	// advance knowledge of how many pages exist -- fall back to the
+	// sequential walk.
+	for opts.Page, opts.URL = meta.Page.Next, meta.Page.NextURL; opts.Page != 0 || opts.URL != ""; {
 		result, meta, err := s.client.Repositories.List(ctx, opts)
 		if err != nil {
 			return nil, err
 		}
-		for _, src := range result {
-			if src != nil {
-				repos = append(repos, convertRepository(src, s.visibility, s.trusted))
-			}
-		}
-		opts.Page = meta.Page.Next
-		opts.URL = meta.Page.NextURL
-
-		if opts.Page == 0 && opts.URL == "" {
-			break
-		}
+		repos = append(repos, convertRepositories(result, s.visibility, s.trusted)...)
+		opts.Page, opts.URL = meta.Page.Next, meta.Page.NextURL
 	}
 	return repos, nil
 }

--- a/service/repo/repo_test.go
+++ b/service/repo/repo_test.go
@@ -247,6 +247,137 @@ func TestList_RefreshErr(t *testing.T) {
 	}
 }
 
+// TestList_ConcurrentPages proves that when the provider reports the
+// total page count up front (meta.Page.Last), List fetches the
+// remaining pages concurrently and still returns every repository,
+// regardless of which goroutine finishes first.
+func TestList_ConcurrentPages(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	mockUser := &core.User{}
+
+	pages := map[int][]*scm.Repository{
+		0: {{Namespace: "octocat", Name: "repo-1"}}, // the first request has no page number set
+		2: {{Namespace: "octocat", Name: "repo-2"}},
+		3: {{Namespace: "octocat", Name: "repo-3"}},
+	}
+
+	mockRepoService := mockscm.NewMockRepositoryService(controller)
+	mockRepoService.EXPECT().
+		List(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+			repos, ok := pages[opts.Page]
+			if !ok {
+				t.Errorf("unexpected page requested: %d", opts.Page)
+			}
+			res := &scm.Response{}
+			if opts.Page == 0 {
+				res.Page.Last = 3
+			}
+			return repos, res, nil
+		}).
+		Times(3)
+
+	mockRenewer := mock.NewMockRenewer(controller)
+	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false)
+
+	client := new(scm.Client)
+	client.Repositories = mockRepoService
+
+	service := New(client, mockRenewer, "", false)
+	got, err := service.List(noContext, mockUser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 repos, got %d: %+v", len(got), got)
+	}
+	names := map[string]bool{}
+	for _, r := range got {
+		names[r.Name] = true
+	}
+	for _, want := range []string{"repo-1", "repo-2", "repo-3"} {
+		if !names[want] {
+			t.Errorf("want repo %q in result, got %+v", want, got)
+		}
+	}
+}
+
+// TestList_ConcurrentPagesErr proves that an error fetching any page
+// fails the whole call.
+func TestList_ConcurrentPagesErr(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	mockUser := &core.User{}
+
+	mockRepoService := mockscm.NewMockRepositoryService(controller)
+	mockRepoService.EXPECT().
+		List(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+			if opts.Page == 0 {
+				res := &scm.Response{}
+				res.Page.Last = 2
+				return []*scm.Repository{{Namespace: "octocat", Name: "repo-1"}}, res, nil
+			}
+			return nil, &scm.Response{}, scm.ErrNotAuthorized
+		}).
+		Times(2)
+
+	mockRenewer := mock.NewMockRenewer(controller)
+	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false)
+
+	client := new(scm.Client)
+	client.Repositories = mockRepoService
+
+	service := New(client, mockRenewer, "", false)
+	_, err := service.List(noContext, mockUser)
+	if err != scm.ErrNotAuthorized {
+		t.Errorf("want not authorized error, got %v", err)
+	}
+}
+
+// TestList_SequentialFallback proves that when the provider only
+// exposes an opaque next-page cursor (no Page.Last), List still walks
+// every page sequentially, in order.
+func TestList_SequentialFallback(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	mockUser := &core.User{}
+
+	mockRepoService := mockscm.NewMockRepositoryService(controller)
+	first := mockRepoService.EXPECT().
+		List(gomock.Any(), scm.ListOptions{Size: 100}).
+		Return([]*scm.Repository{{Namespace: "octocat", Name: "repo-1"}},
+			&scm.Response{Page: scm.Page{NextURL: "https://example.com/repos?cursor=abc"}}, nil)
+	mockRepoService.EXPECT().
+		List(gomock.Any(), scm.ListOptions{Size: 100, URL: "https://example.com/repos?cursor=abc"}).
+		Return([]*scm.Repository{{Namespace: "octocat", Name: "repo-2"}}, &scm.Response{}, nil).
+		After(first)
+
+	mockRenewer := mock.NewMockRenewer(controller)
+	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false)
+
+	client := new(scm.Client)
+	client.Repositories = mockRepoService
+
+	want := []*core.Repository{
+		{Namespace: "octocat", Name: "repo-1", Slug: "octocat/repo-1", Visibility: "public"},
+		{Namespace: "octocat", Name: "repo-2", Slug: "octocat/repo-2", Visibility: "public"},
+	}
+
+	service := New(client, mockRenewer, "", false)
+	got, err := service.List(noContext, mockUser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Diff: %s", diff)
+	}
+}
+
 func TestListWithNilRepo(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()

--- a/service/repo/util.go
+++ b/service/repo/util.go
@@ -39,6 +39,19 @@ func convertRepository(src *scm.Repository, visibility string, trusted bool) *co
 	}
 }
 
+// convertRepositories converts a page of repositories from the
+// source code management system to the local datastructure, skipping
+// any nil entries.
+func convertRepositories(src []*scm.Repository, visibility string, trusted bool) []*core.Repository {
+	out := make([]*core.Repository, 0, len(src))
+	for _, s := range src {
+		if s != nil {
+			out = append(out, convertRepository(s, visibility, trusted))
+		}
+	}
+	return out
+}
+
 // convertVisibility is a helper function that returns the
 // repository visibility based on the privacy flag.
 func convertVisibility(src *scm.Repository, visibility string) string {

--- a/store/batch2/batch.go
+++ b/store/batch2/batch.go
@@ -22,6 +22,8 @@ import (
 	"github.com/drone/drone/core"
 	"github.com/drone/drone/store/repos"
 	"github.com/drone/drone/store/shared/db"
+
+	"github.com/lib/pq"
 )
 
 // New returns a new Batcher.
@@ -80,6 +82,13 @@ func (b *batchUpdater) Batch(ctx context.Context, user *core.User, batch *core.B
 			}
 		}
 
+		// perms for the repos in insert/update are the same shape
+		// regardless of which branch a repo landed in (perm_read=true,
+		// perm_write=false, perm_admin=false, perm_synced=0), so on
+		// postgres they are collected here and written once, below, as
+		// a single batched upsert instead of one INSERT per repo.
+		var permUIDsPostgres []string
+
 		for _, repo := range insert {
 
 			//
@@ -107,15 +116,16 @@ func (b *batchUpdater) Batch(ctx context.Context, user *core.User, batch *core.B
 
 			//
 			// insert permissions
-			// TODO: group inserts in batches of N
 			//
 
+			if b.db.Driver() == db.Postgres {
+				permUIDsPostgres = append(permUIDsPostgres, repo.UID)
+				continue
+			}
+
 			stmt = permInsertIgnoreStmt
-			switch b.db.Driver() {
-			case db.Mysql:
+			if b.db.Driver() == db.Mysql {
 				stmt = permInsertIgnoreStmtMysql
-			case db.Postgres:
-				stmt = permInsertIgnoreStmtPostgres
 			}
 
 			_, err = execer.Exec(stmt,
@@ -178,12 +188,14 @@ func (b *batchUpdater) Batch(ctx context.Context, user *core.User, batch *core.B
 			}
 			// }
 
+			if b.db.Driver() == db.Postgres {
+				permUIDsPostgres = append(permUIDsPostgres, repo.UID)
+				continue
+			}
+
 			stmt = permInsertIgnoreStmt
-			switch b.db.Driver() {
-			case db.Mysql:
+			if b.db.Driver() == db.Mysql {
 				stmt = permInsertIgnoreStmtMysql
-			case db.Postgres:
-				stmt = permInsertIgnoreStmtPostgres
 			}
 
 			_, err = execer.Exec(stmt,
@@ -194,6 +206,22 @@ func (b *batchUpdater) Batch(ctx context.Context, user *core.User, batch *core.B
 			)
 			if err != nil {
 				return fmt.Errorf("batch: cannot insert permissions: %s: %s: %s", repo.Slug, repo.UID, err)
+			}
+		}
+
+		// a single round trip for every permission collected above,
+		// in place of one INSERT per repo (this was, by call volume
+		// and lock time, the single most expensive statement in this
+		// function -- see permInsertIgnoreBatchStmtPostgres).
+		if len(permUIDsPostgres) > 0 {
+			_, err := execer.Exec(permInsertIgnoreBatchStmtPostgres,
+				user.ID,
+				now,
+				now,
+				pq.Array(permUIDsPostgres),
+			)
+			if err != nil {
+				return fmt.Errorf("batch: cannot insert permissions: %s", err)
 			}
 		}
 
@@ -366,7 +394,10 @@ INSERT IGNORE INTO perms (
 )
 `
 
-const permInsertIgnoreStmtPostgres = `
+// permInsertIgnoreBatchStmtPostgres inserts one permission row per
+// repo UID in $4, in a single round trip, in place of a loop issuing
+// one single-row INSERT per repo.
+const permInsertIgnoreBatchStmtPostgres = `
 INSERT INTO perms (
  perm_user_id
 ,perm_repo_uid
@@ -376,16 +407,10 @@ INSERT INTO perms (
 ,perm_synced
 ,perm_created
 ,perm_updated
-) values (
- $1
-,$2
-,true
-,false
-,false
-,0
-,$3
-,$4
-) ON CONFLICT DO NOTHING
+)
+SELECT $1, repo_uid, true, false, false, 0, $2, $3
+FROM unnest($4::text[]) AS repo_uid
+ON CONFLICT DO NOTHING
 `
 
 // this statement deletes a repository that was

--- a/store/batch2/batch_test.go
+++ b/store/batch2/batch_test.go
@@ -41,6 +41,7 @@ func TestBatch(t *testing.T) {
 	}
 
 	t.Run("Insert", testBatchInsert(batcher, repos, perms, user))
+	t.Run("InsertMultiple", testBatchInsertMultiple(batcher, repos, perms, user))
 	t.Run("Update", testBatchUpdate(batcher, repos, perms, user))
 	t.Run("Delete", testBatchDelete(batcher, repos, perms, user))
 	t.Run("DuplicateID", testBatchDuplicateID(batcher, repos, perms, user))
@@ -83,6 +84,38 @@ func testBatchInsert(
 		_, err = perms.Find(noContext, repo.UID, user.ID)
 		if err != nil {
 			t.Errorf("Want permissions, got error %q", err)
+		}
+	}
+}
+
+// testBatchInsertMultiple proves that a single Batch() call carrying
+// several new repositories still grants a permission row for every
+// one of them -- the case the batched permInsertIgnoreBatchStmtPostgres
+// call (in place of one INSERT per repo) needs to get right.
+func testBatchInsertMultiple(
+	batcher core.Batcher,
+	repos core.RepositoryStore,
+	perms core.PermStore,
+	user *core.User,
+) func(t *testing.T) {
+	return func(t *testing.T) {
+		batch := &core.Batch{
+			Insert: []*core.Repository{
+				{UserID: 1, UID: "301", Namespace: "octocat", Name: "multi-a", Slug: "octocat/multi-a"},
+				{UserID: 1, UID: "302", Namespace: "octocat", Name: "multi-b", Slug: "octocat/multi-b"},
+				{UserID: 1, UID: "303", Namespace: "octocat", Name: "multi-c", Slug: "octocat/multi-c"},
+			},
+		}
+		err := batcher.Batch(noContext, user, batch)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		for _, uid := range []string{"301", "302", "303"} {
+			if _, err := perms.Find(noContext, uid, user.ID); err != nil {
+				t.Errorf("Want permissions for repo %s, got error %q", uid, err)
+			}
 		}
 	}
 }

--- a/store/build/build.go
+++ b/store/build/build.go
@@ -447,10 +447,17 @@ func (s *buildStore) Purge(ctx context.Context, repo, number int64) error {
 	return nil
 }
 
-// Count returns a count of builds.
+// Count returns a count of builds. On Postgres this is a fast
+// planner estimate (refreshed by autovacuum/ANALYZE) rather than an
+// exact count, since callers only use this for periodic metrics and
+// dashboard stats, not anything transactional.
 func (s *buildStore) Count(ctx context.Context) (i int64, err error) {
+	query := queryCount
+	if s.db.Driver() == db.Postgres {
+		query = queryCountPostgres
+	}
 	err = s.db.View(func(queryer db.Queryer, binder db.Binder) error {
-		return queryer.QueryRow(queryCount).Scan(&i)
+		return queryer.QueryRow(query).Scan(&i)
 	})
 	return
 }
@@ -458,6 +465,12 @@ func (s *buildStore) Count(ctx context.Context) (i int64, err error) {
 const queryCount = `
 SELECT COUNT(*)
 FROM builds
+`
+
+const queryCountPostgres = `
+SELECT reltuples::bigint
+FROM pg_class
+WHERE relname = 'builds'
 `
 
 const queryBase = `

--- a/store/build/build_test.go
+++ b/store/build/build_test.go
@@ -18,6 +18,19 @@ import (
 
 var noContext = context.TODO()
 
+// analyzeBuilds refreshes the planner statistics backing Count() on
+// Postgres, where the count is an estimate (see queryCountPostgres)
+// rather than an exact COUNT(*). It is a no-op on other drivers.
+func analyzeBuilds(store *buildStore) {
+	if store.db.Driver() != db.Postgres {
+		return
+	}
+	_ = store.db.Update(func(execer db.Execer, binder db.Binder) error {
+		_, err := execer.Exec("ANALYZE builds")
+		return err
+	})
+}
+
 func TestBuild(t *testing.T) {
 	conn, err := dbtest.Connect()
 	if err != nil {
@@ -303,6 +316,7 @@ func testBuildCount(store *buildStore) func(t *testing.T) {
 		_ = store.Create(noContext, &core.Build{RepoID: 1, Number: 100}, nil)
 		_ = store.Create(noContext, &core.Build{RepoID: 1, Number: 101}, nil)
 
+		analyzeBuilds(store)
 		count, err := store.Count(noContext)
 		if err != nil {
 			t.Error(err)
@@ -324,6 +338,7 @@ func testBuildPending(store *buildStore) func(t *testing.T) {
 		_ = store.Create(noContext, &core.Build{RepoID: 1, Number: 100, Status: core.StatusRunning}, []*core.Stage{{RepoID: 1, Number: 1, Status: core.StatusRunning}})
 		_ = store.Create(noContext, &core.Build{RepoID: 1, Number: 101, Status: core.StatusPassing}, []*core.Stage{{RepoID: 1, Number: 1, Status: core.StatusPassing}})
 
+		analyzeBuilds(store)
 		count, err := store.Count(noContext)
 		if err != nil {
 			t.Error(err)
@@ -351,6 +366,7 @@ func testBuildRunning(store *buildStore) func(t *testing.T) {
 		_ = store.Create(noContext, &core.Build{RepoID: 1, Number: 100, Status: core.StatusBlocked}, []*core.Stage{{RepoID: 1, Number: 1, Status: core.StatusBlocked}})
 		_ = store.Create(noContext, &core.Build{RepoID: 1, Number: 101, Status: core.StatusPassing}, []*core.Stage{{RepoID: 1, Number: 1, Status: core.StatusPassing}})
 
+		analyzeBuilds(store)
 		count, err := store.Count(noContext)
 		if err != nil {
 			t.Error(err)

--- a/store/repos/repos.go
+++ b/store/repos/repos.go
@@ -493,18 +493,6 @@ WHERE repo_id = :repo_id
   AND repo_version = :repo_version_old
 `
 
-// TODO(bradrydzewski) this query needs performance tuning.
-// one approach that is promising is the ability to use the
-// repo_counter (latest build number) to join on the build
-// table.
-//
-//   FROM repos LEFT OUTER JOIN builds ON (
-//     repos.repo_id = builds.build_repo_id AND
-//     builds.build_number = repos.repo_counter
-//   )
-//   INNER JOIN perms ON perms.perm_repo_uid = repos.repo_uid
-//
-
 const queryRepoWithBuild = queryColsBuilds + `
 FROM repos LEFT OUTER JOIN builds ON build_id = (
 	SELECT build_id FROM builds
@@ -517,12 +505,16 @@ WHERE perms.perm_user_id = :user_id
 ORDER BY repo_slug ASC
 `
 
+// queryRepoWithBuildPostgres resolves each repo's latest build with
+// a plain equality join instead of a per-row correlated subquery.
+// repos.repo_counter is incremented atomically as a build number is
+// issued (see RepositoryStore.Increment, called from trigger.go), so
+// it always names the repo's current latest build, and
+// builds(build_repo_id, build_number) is already unique and indexed.
 const queryRepoWithBuildPostgres = queryColsBuilds + `
-FROM repos LEFT OUTER JOIN builds ON build_id = (
-	SELECT DISTINCT ON (build_repo_id) build_id FROM builds
-	WHERE builds.build_repo_id = repos.repo_id
-	ORDER BY build_repo_id, build_id DESC
-)
+FROM repos LEFT OUTER JOIN builds
+	ON builds.build_repo_id = repos.repo_id
+	AND builds.build_number = repos.repo_counter
 INNER JOIN perms ON perms.perm_repo_uid = repos.repo_uid
 WHERE perms.perm_user_id = :user_id
 ORDER BY repo_slug ASC

--- a/store/repos/repos_test.go
+++ b/store/repos/repos_test.go
@@ -40,6 +40,7 @@ func TestRepo(t *testing.T) {
 	t.Run("FindName", testRepoFindName(store))
 	t.Run("List", testRepoList(store))
 	t.Run("ListLatest", testRepoListLatest(store))
+	t.Run("ListLatestByCounter", testRepoListLatestByCounter(store))
 	t.Run("Update", testRepoUpdate(store))
 	t.Run("Activate", testRepoActivate(store))
 	t.Run("Locking", testRepoLocking(store))
@@ -211,6 +212,66 @@ func testRepoListLatest(repos *repoStore) func(t *testing.T) {
 			t.Errorf("Expect nil build")
 		} else {
 			t.Run("Fields", testRepo(repos[0]))
+		}
+	}
+}
+
+// testRepoListLatestByCounter proves that queryRepoWithBuildPostgres
+// resolves the repo's build via repo_counter, not via insertion order
+// or build_id. It inserts the higher-numbered build first (so it gets
+// the lower build_id) and the lower-numbered build second (so it gets
+// the higher build_id) -- the old per-row subquery ordered by
+// build_id DESC would have picked the wrong one.
+func testRepoListLatestByCounter(repos *repoStore) func(t *testing.T) {
+	return func(t *testing.T) {
+		if repos.db.Driver() != db.Postgres {
+			t.Skip("queryRepoWithBuildPostgres only runs on the postgres driver")
+		}
+
+		repo, err := repos.FindName(noContext, "octocat", "hello-world")
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		insert := func(number int64) {
+			err := repos.db.Update(func(execer db.Execer, binder db.Binder) error {
+				_, err := execer.Exec(
+					`INSERT INTO builds (build_repo_id, build_number, build_status) VALUES ($1, $2, '')`,
+					repo.ID, number,
+				)
+				return err
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		defer func() {
+			_ = repos.db.Update(func(execer db.Execer, binder db.Binder) error {
+				_, err := execer.Exec(`DELETE FROM builds WHERE build_repo_id = $1`, repo.ID)
+				return err
+			})
+		}()
+
+		insert(7) // higher number, inserted (and therefore lower build_id) first
+		insert(4) // lower number, inserted (and therefore higher build_id) second
+
+		repo.Counter = 7
+		if err := repos.Update(noContext, repo); err != nil {
+			t.Error(err)
+			return
+		}
+
+		list, err := repos.ListLatest(noContext, 1)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if len(list) != 1 || list[0].Build == nil {
+			t.Fatalf("want exactly one repo with a build, got %+v", list)
+		}
+		if got, want := list[0].Build.Number, int64(7); got != want {
+			t.Errorf("Want latest build number %d (repo_counter), got %d", want, got)
 		}
 	}
 }


### PR DESCRIPTION
Reason for this change

A Query Insights audit of a production Drone Postgres instance found that database load was extremely concentrated: one query accounted for ~94% of all execution time across the top 20 costliest query shapes (~21.3 of ~22.7 CPU-hours/week). A follow-up look at why the UI itself feels slow found the same pattern one layer up, in the repository-sync flow's SCM API calls and database writes.

This PR fixes the four highest-impact findings from that audit, each as its own commit:

1. 2d77a063a — build count metric runs a full table scan every ~minute. SELECT COUNT(*) FROM builds can't use an index-only scan under Postgres MVCC. Called from the Prometheus/Datadog metric sinks and /api/system/stats roughly once a minute (10k calls/week, ~85ms each, ~850s/week total) for callers that only need an approximate count. Now uses pg_class.reltuples on Postgres; other drivers are unchanged.
2. c628e5fe4 — repo dashboard resolves each repo's latest build with a per-row subquery. This was the dominant cost: 8,449 calls/week at ~9.08s average (~21.3 CPU-hours/week), from a DISTINCT ON subquery re-scanned and sorted once per visible repo. repos.repo_counter is incremented atomically as a build number is issued, so it always names the repo's current latest build — replaced the subquery with a plain equality join on builds(build_repo_id, build_number), which is already unique and indexed. This was already flagged with a TODO in the source proposing this exact fix.
3. 3ab57fe4f — permission sync writes one row at a time. Every repo permission sync issued one INSERT INTO perms per repo — ~131k calls/week and the single largest lock-time total of any query on the instance (56.7s/week). The row shape is identical whether the repo is new or existing, so both insert paths now collect repo UIDs and write them in one batched upsert via unnest(), on Postgres only.
4. 129bdf13a — SCM repository-list pagination is fully sequential. For accounts with hundreds/thousands of repos, listing repos from GitHub made that many sequential page-by-page round trips — the login-sync code's own comment admits this "can take up to a few minutes." go-scm's Link-header parser exposes the total page count up front for GitHub, so remaining pages now fetch concurrently via errgroup (capped at 6, to respect secondary rate limits), with the original sequential walk kept as a fallback for providers that only expose an opaque cursor.

Example usage / expected output

Before, on the production instance: ListLatest averaged 9.08s per call and accounted for ~94% of top-20 query time; perms inserts showed the highest lock-time total of any statement; builds.Count() scanned the full table every minute. After these changes, the equivalent queries should drop off the Query Insights top-cost list — the ListLatest query hash in particular should go from ~9s average to sub-millisecond, since it becomes an indexed equality join instead of a per-row correlated subquery.

Steps to test the change
```
go build ./...
go vet ./...
go test ./...                    # sqlite (default local/CI driver) — full suite passes
task test-postgres               # exercises the actual Postgres-specific rewrites in commits 1–3
go test ./service/repo/... -race # commit 4's concurrency change
```

All four commits pass go build, go vet, and the full go test ./... suite. Commits 1–3 (the Postgres-specific rewrites) additionally verified against a real postgres:9-alpine container via `task test-postgres`, including new regression tests: TestRepo/ListLatestByCounter (proves the join keys off repo_counter, not insertion/build_id order), TestBatch/InsertMultiple (proves a single Batch() call with several new repos still grants permissions for all of them), and the existing TestBuild/Count (re-verified against the Postgres estimate path). Commit 4 additionally verified under -race.